### PR TITLE
reflect the state of the job in the frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Job posting
 
-For **new job postings**, copy from [the template](pages/positions/template_upcoming-position.md), and uncomment (remove the `# ` in front of) `state: upcoming`.
+For **new job postings**, copy from [the template](pages/positions/template_upcoming-position.md).
 
 To **open an upcoming job**, change the `state` to `open` in the "frontmatter" (the metadata between the horizontal lines at the top).
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 
 ## Job posting
 
-For **new job postings**, copy from [the template](pages/positions/template_upcoming-position.md).
+For **new job postings**, copy from [the template](pages/positions/template_upcoming-position.md), and uncomment (remove the `# ` in front of) `state: upcoming`.
 
-To **close a job posting**, make sure to
+To **open an upcoming job**, change the `state` to `open` in the "frontmatter" (the metadata between the horizontal lines at the top).
 
-* Add a `state: closed` line to the "frontmatter" (the metadata between the horizontal lines at the top)
-* Remove from [the homepage](pages/index.md)
+To **close a job posting**, change the `state` to `closed`.
+
+To **reuse a job posting**, change the `state` to `upcoming`, and modify the page as appropriate.
 
 ## Local development
 

--- a/_layouts/custom.html
+++ b/_layouts/custom.html
@@ -10,13 +10,14 @@ layout: page
       <a href="{{site.baseurl}}/#join-us">our other open positions</a>.</p>
   </div>
 </div>
+{% elsif page.state == 'upcoming' %}
+<div class="usa-alert usa-alert-info">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Upcoming role</h3>
+    <p class="usa-alert-text">This role is not yet open to apply to. See below for details.</p>
+  </div>
+</div>
 {% endif %}
 
-<h1>
-  {% if page.state == 'upcoming' %}
-  Upcoming Role -
-  {% endif %}
-  {{ page.title }}
-</h1>
-
+<h1>{{ page.title }}</h1>
 {{ content }}

--- a/_layouts/custom.html
+++ b/_layouts/custom.html
@@ -12,5 +12,11 @@ layout: page
 </div>
 {% endif %}
 
-<h1>{{ page.title }}</h1>
+<h1>
+  {% if page.state == 'upcoming' %}
+  Upcoming Role -
+  {% endif %}
+  {{ page.title }}
+</h1>
+
 {{ content }}

--- a/pages/index.md
+++ b/pages/index.md
@@ -34,7 +34,7 @@ We’re looking for candidates passionate about our mission with top-notch softw
 {% for pg in sortedpages %}
 {% if pg.state == 'upcoming' %}
 {% unless pg.path contains 'template'  %}
-* [{{ pg.title | remove: "Upcoming Role - " }}]({{ site.baseurl }}{{ pg.permalink }})
+* [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }})
 {% endunless %}
 {% endif %}
 {% endfor %}

--- a/pages/index.md
+++ b/pages/index.md
@@ -27,19 +27,23 @@ In [this video](https://www.youtube.com/watch?v=WURf2Z1uTaI) members of TTS shar
 
 We’re looking for candidates passionate about our mission with top-notch software development, product management, procurement, design, content, cloud migration, outreach or operations skills to match.
 
+{% assign sortedpages = site.pages | sort: 'title' %}
+
 ### Upcoming Positions
 
-- [Cloud Adoption Specialist]({{site.baseurl}}/join/CoE-cloud-adoption-specialist/)
-- [Customer Experience Specialist]({{site.baseurl}}/join/coe-customer-experience-specialist/)
-- [Contact Center Optimization Specialist]({{site.baseurl}}/join/coe-contact-center-optimization-specialist/)
-- [Infrastructure Optimization Specialist]({{site.baseurl}}/join/coe-infrastructure-optimization-specialist/)
-- [Data & Analytics Specialist]({{site.baseurl}}/join/coe-data-and-analytics-specialist/)
-- [Consulting Software Engineer]({{site.baseurl}}/join/18F-consulting-software-engineer/)
+{% for pg in sortedpages %}
+{% if pg.state == 'upcoming' %}
+* [{{ pg.title | remove: "Upcoming Role - " }}]({{ site.baseurl }}{{ pg.permalink }})
+{% endif %}
+{% endfor %}
 
 ### Open Positions
 
-- [Product Manager]({{site.baseurl}}/join/18f-product-manager/) (Open now through Friday, June 8, 2018 at 8:00pm)
-- [Presidential Innovation Fellow]({{site.baseurl}}/join/pif-presidential-innovation-fellow/) (Open now through Sunday, June 24, 2018 at 11:59pm EDT)
+{% for pg in sortedpages %}
+{% if pg.state == 'open' %}
+* [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }})
+{% endif %}
+{% endfor %}
 
  **We are hiring and will be sharing information on new upcoming jobs as well as releasing new job postings frequently. Please check back or if you would like to be notified when new jobs are posted, [join our mailing list](https://docs.google.com/forms/d/e/1FAIpQLSf-HCWKQp_3TKJs0ss-3IqzbI0HY16rH5LnV8CRpIBykeH07g/viewform?usp=sf_link).**
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -33,7 +33,9 @@ We’re looking for candidates passionate about our mission with top-notch softw
 
 {% for pg in sortedpages %}
 {% if pg.state == 'upcoming' %}
+{% unless pg.path contains 'template'  %}
 * [{{ pg.title | remove: "Upcoming Role - " }}]({{ site.baseurl }}{{ pg.permalink }})
+{% endunless %}
 {% endif %}
 {% endfor %}
 
@@ -41,7 +43,9 @@ We’re looking for candidates passionate about our mission with top-notch softw
 
 {% for pg in sortedpages %}
 {% if pg.state == 'open' %}
+{% unless pg.path contains 'template'  %}
 * [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }})
+{% endunless %}
 {% endif %}
 {% endfor %}
 

--- a/pages/positions/18f-product-manager-2-gs15.md
+++ b/pages/positions/18f-product-manager-2-gs15.md
@@ -1,6 +1,7 @@
 ---
 title: Product Manager
 permalink: /join/18f-product-manager/
+state: open
 
 subnav:
   - text: Role summary

--- a/pages/positions/18f-product-manager-gs15.md
+++ b/pages/positions/18f-product-manager-gs15.md
@@ -4,7 +4,6 @@ permalink: /join/product-manager-gs15/
 redirect_from:
   - /join/product-manager-gs15-closed/
 state: closed
-app_close_date: FEBRUARY 26, 2018
 
 subnav:
   - text: Role summary

--- a/pages/positions/18f-upcoming-consulting-software-engineer-gs15.md
+++ b/pages/positions/18f-upcoming-consulting-software-engineer-gs15.md
@@ -1,5 +1,5 @@
 ---
-title: Upcoming Role - 18F Consulting Software Engineer
+title: 18F Consulting Software Engineer
 permalink: join/18F-consulting-software-engineer/
 redirect_from:
   - /join/upcoming-18F-consulting-software-engineer/

--- a/pages/positions/18f-upcoming-consulting-software-engineer-gs15.md
+++ b/pages/positions/18f-upcoming-consulting-software-engineer-gs15.md
@@ -3,6 +3,7 @@ title: Upcoming Role - 18F Consulting Software Engineer
 permalink: join/18F-consulting-software-engineer/
 redirect_from:
   - /join/upcoming-18F-consulting-software-engineer/
+state: upcoming
 
 subnav:
  - text: Basic information

--- a/pages/positions/18f-upcoming-product-manager-gs15.md
+++ b/pages/positions/18f-upcoming-product-manager-gs15.md
@@ -1,5 +1,5 @@
 ---
-title: Upcoming Role - 18F Product Manager
+title: 18F Product Manager
 permalink: join/upcoming-18F-product-manager/
 state: upcoming
 

--- a/pages/positions/18f-upcoming-product-manager-gs15.md
+++ b/pages/positions/18f-upcoming-product-manager-gs15.md
@@ -1,6 +1,7 @@
 ---
 title: Upcoming Role - 18F Product Manager
 permalink: join/upcoming-18F-product-manager/
+state: upcoming
 
 subnav:
  - text: Basic information

--- a/pages/positions/18f-upcoming-ux-designer-gs15.md
+++ b/pages/positions/18f-upcoming-ux-designer-gs15.md
@@ -3,6 +3,7 @@ title: Upcoming Role - 18F User Experience Designer
 permalink: join/18F-user-experience-designer/
 redirect_from:
   - join/upcoming-18F-user-experience-designer/
+state: upcoming
 
 subnav:
  - text: Basic information

--- a/pages/positions/18f-upcoming-ux-designer-gs15.md
+++ b/pages/positions/18f-upcoming-ux-designer-gs15.md
@@ -1,5 +1,5 @@
 ---
-title: Upcoming Role - 18F User Experience Designer
+title: 18F User Experience Designer
 permalink: join/18F-user-experience-designer/
 redirect_from:
   - join/upcoming-18F-user-experience-designer/

--- a/pages/positions/acq-user-experience-design-lead-gs15.md
+++ b/pages/positions/acq-user-experience-design-lead-gs15.md
@@ -4,7 +4,6 @@ permalink: /join/user-experience-design-lead-gs15/
 redirect_from:
   - /join/user-experience-design-lead-gs15-closed/
 state: closed
-app_close_date: APRIL 6, 2018
 
 subnav:
   - text: Role summary

--- a/pages/positions/coe-upcoming-cloud-adoption-specialist-gs15.md
+++ b/pages/positions/coe-upcoming-cloud-adoption-specialist-gs15.md
@@ -3,6 +3,7 @@ title: Upcoming Role - CoE Cloud Adoption Specialist
 permalink: join/CoE-cloud-adoption-specialist/
 redirect_from:
   - join/upcoming-CoE-cloud-adoption-specialist/
+state: upcoming
 
 subnav:
  - text: Basic information

--- a/pages/positions/coe-upcoming-cloud-adoption-specialist-gs15.md
+++ b/pages/positions/coe-upcoming-cloud-adoption-specialist-gs15.md
@@ -1,5 +1,5 @@
 ---
-title: Upcoming Role - CoE Cloud Adoption Specialist
+title: CoE Cloud Adoption Specialist
 permalink: join/CoE-cloud-adoption-specialist/
 redirect_from:
   - join/upcoming-CoE-cloud-adoption-specialist/

--- a/pages/positions/coe-upcoming-contact-center-optimization-specialist-gs15.md
+++ b/pages/positions/coe-upcoming-contact-center-optimization-specialist-gs15.md
@@ -1,5 +1,5 @@
 ---
-title: Upcoming Role - CoE Contact Center Optimization Specialist
+title: CoE Contact Center Optimization Specialist
 permalink: join/coe-contact-center-optimization-specialist/
 redirect_from:
   - join/upcoming-coe-contact-center-optimization-specialist/

--- a/pages/positions/coe-upcoming-contact-center-optimization-specialist-gs15.md
+++ b/pages/positions/coe-upcoming-contact-center-optimization-specialist-gs15.md
@@ -3,6 +3,7 @@ title: Upcoming Role - CoE Contact Center Optimization Specialist
 permalink: join/coe-contact-center-optimization-specialist/
 redirect_from:
   - join/upcoming-coe-contact-center-optimization-specialist/
+state: upcoming
 
 subnav:
  - text: Basic information

--- a/pages/positions/coe-upcoming-customer-experience-specialist.md
+++ b/pages/positions/coe-upcoming-customer-experience-specialist.md
@@ -1,5 +1,5 @@
 ---
-title: Upcoming Role - CoE Customer Experience Specialist
+title: CoE Customer Experience Specialist
 permalink: join/coe-customer-experience-specialist/
 redirect_from:
   - join/upcoming-coe-customer-experience-specialist/

--- a/pages/positions/coe-upcoming-customer-experience-specialist.md
+++ b/pages/positions/coe-upcoming-customer-experience-specialist.md
@@ -3,6 +3,7 @@ title: Upcoming Role - CoE Customer Experience Specialist
 permalink: join/coe-customer-experience-specialist/
 redirect_from:
   - join/upcoming-coe-customer-experience-specialist/
+state: upcoming
 
 subnav:
  - text: Basic information

--- a/pages/positions/coe-upcoming-data-and-analytics-specialist.md
+++ b/pages/positions/coe-upcoming-data-and-analytics-specialist.md
@@ -1,5 +1,5 @@
 ---
-title: Upcoming Role - CoE Data & Analytics Specialist
+title: CoE Data & Analytics Specialist
 permalink: join/coe-data-and-analytics-specialist/
 redirect_from:
   - join/upcoming-coe-data-and-analytics-specialist/

--- a/pages/positions/coe-upcoming-data-and-analytics-specialist.md
+++ b/pages/positions/coe-upcoming-data-and-analytics-specialist.md
@@ -3,6 +3,7 @@ title: Upcoming Role - CoE Data & Analytics Specialist
 permalink: join/coe-data-and-analytics-specialist/
 redirect_from:
   - join/upcoming-coe-data-and-analytics-specialist/
+state: upcoming
 
 subnav:
  - text: Basic information

--- a/pages/positions/coe-upcoming-infrastructure-optimization-specialist.md
+++ b/pages/positions/coe-upcoming-infrastructure-optimization-specialist.md
@@ -1,5 +1,5 @@
 ---
-title: Upcoming Role - CoE Infrastructure Optimization Specialist
+title: CoE Infrastructure Optimization Specialist
 permalink: join/coe-infrastructure-optimization-specialist/
 redirect_from:
   - join/upcoming-coe-infrastructure-optimization-specialist/

--- a/pages/positions/coe-upcoming-infrastructure-optimization-specialist.md
+++ b/pages/positions/coe-upcoming-infrastructure-optimization-specialist.md
@@ -3,6 +3,7 @@ title: Upcoming Role - CoE Infrastructure Optimization Specialist
 permalink: join/coe-infrastructure-optimization-specialist/
 redirect_from:
   - join/upcoming-coe-infrastructure-optimization-specialist/
+state: upcoming
 
 subnav:
  - text: Basic information

--- a/pages/positions/pif-presidential-innovation-fellow-gs15.md
+++ b/pages/positions/pif-presidential-innovation-fellow-gs15.md
@@ -1,6 +1,7 @@
 ---
 title: Presidential Innovation Fellow
 permalink: /join/pif-presidential-innovation-fellow/
+state: open
 
 subnav:
   - text: Role summary

--- a/pages/positions/template_upcoming-position.md
+++ b/pages/positions/template_upcoming-position.md
@@ -1,7 +1,7 @@
 ---
-title: Upcoming Role - 18F Consulting Software Engineer
+title: Upcoming Role - TITLE
 permalink: join/OFFICE-ROLE-GS LEVEL/
-# state: upcoming
+state: upcoming
 
 subnav:
  - text: Basic information

--- a/pages/positions/template_upcoming-position.md
+++ b/pages/positions/template_upcoming-position.md
@@ -1,6 +1,7 @@
 ---
 title: Upcoming Role - 18F Consulting Software Engineer
 permalink: join/OFFICE-ROLE-GS LEVEL/
+# state: upcoming
 
 subnav:
  - text: Basic information

--- a/pages/positions/template_upcoming-position.md
+++ b/pages/positions/template_upcoming-position.md
@@ -1,5 +1,5 @@
 ---
-title: Upcoming Role - TITLE
+title: TITLE
 permalink: join/OFFICE-ROLE-GS LEVEL/
 state: upcoming
 


### PR DESCRIPTION
Builds on #89.

This pull request adds the `state` field to all job postings, and uses that to generate the list of current and future job openings dynamically. This means that list no longer needs to be maintained manually. Kudos to @rooneywp for the idea!

Known differences ([before](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/states/#join-us) and [after](https://join.tts.gsa.gov/#join-us)):

* There are more upcoming jobs listed. Not sure if this was intentional...?
* All the upcoming job titles start with the name of the office. Not sure if this was intentional...?
* There aren't close dates next to the open positions. Just a bit more work, but didn't want to make this pull request too huge. Understand if it's a blocker to merging this though.
* Upcoming job posts now have an alert showing that it's upcoming, rather than prefixing the title.

Let me know what you think!