### PR TITLE
automatically inject the 'how to apply' information based on metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 For **new job postings**, copy from [the template](pages/positions/template_upcoming-position.md).
 
-To **open an upcoming job**, change the `state` to `open` in the "frontmatter" (the metadata between the horizontal lines at the top).
+To **open an upcoming job**, in the "frontmatter" (the metadata between the horizontal lines at the top): change the `state` to `open`, and make sure the other fields are filled in.
 
 To **close a job posting**, change the `state` to `closed`.
 

--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,11 @@ defaults:
     values:
       layout: custom
       sidenav: primary
+  - scope:
+      path: pages/positions
+      type: pages
+    values:
+      layout: job
 
 styles:
   - /assets/css/site.css

--- a/_includes/how_to_apply.md
+++ b/_includes/how_to_apply.md
@@ -1,7 +1,7 @@
 ## How To Apply
 
 {% if page.state == 'upcoming' %}
-{% include upcoming_statement.md %}
+{% include upcoming_statement.html %}
 {% elsif page.state == 'closed' %}
 We're sorry, this job has closed.
 {% elsif page.state == 'open' %}

--- a/_includes/how_to_apply.md
+++ b/_includes/how_to_apply.md
@@ -2,10 +2,11 @@
 
 {% if page.state == 'upcoming' %}
 {% include upcoming_statement.html %}
-{% elsif page.state == 'closed' %}
-We're sorry, this job has closed.
-{% elsif page.state == 'open' %}
+{% else %}
 
+{% if page.state == 'closed' %}
+We're sorry, this job has closed.
+{% else %}
 Submit a complete online application prior to {{ page.closes | date: '%l:%M%P %Z on %A, %B %e, %Y' }}. Please fill out all applicable fields.
 
 <section class="usa-grid-full">
@@ -13,6 +14,7 @@ Submit a complete online application prior to {{ page.closes | date: '%l:%M%P %Z
 </section>
 
 **Need Assistance in applying or have questions regarding this job opportunity, please email {{ page.contact_name }} at** [{{ page.contact_email }}](mailto:{{ page.contact_email }}).
+{% endif %}
 
 ### Required Documents
 

--- a/_includes/how_to_apply.md
+++ b/_includes/how_to_apply.md
@@ -1,3 +1,13 @@
+## How To Apply
+
+Submit a complete online application prior to {{ page.closes | date: '%l:%M%P %Z on %A, %B %e, %Y' }}. Please fill out all applicable fields.
+
+<section class="usa-grid-full">
+  <a class="usa-button usa-button-secondary" href="{{ page.apply_url }}">Click here to apply</a>
+</section>
+
+**Need Assistance in applying or have questions regarding this job opportunity, please email {{ page.contact_name }} at** [{{ page.contact_email }}](mailto:{{ page.contact_email }}).
+
 ### Required Documents
 
 **ALL** required documents must be submitted before the closing date to be considered for the role. Review the following list to determine what you need to submit.

--- a/_includes/how_to_apply.md
+++ b/_includes/how_to_apply.md
@@ -1,5 +1,11 @@
 ## How To Apply
 
+{% if page.state == 'upcoming' %}
+{% include upcoming_statement.md %}
+{% elsif page.state == 'closed' %}
+We're sorry, this job has closed.
+{% elsif page.state == 'open' %}
+
 Submit a complete online application prior to {{ page.closes | date: '%l:%M%P %Z on %A, %B %e, %Y' }}. Please fill out all applicable fields.
 
 <section class="usa-grid-full">
@@ -62,3 +68,4 @@ After the closing date:
 4. **FINAL JOB OFFER:** Once our security office determines you can come on board, you will be given a final offer.
 
 **Thank you for your interest in working for U.S. General Services Administration!**
+{% endif %}

--- a/_includes/upcoming_statement.html
+++ b/_includes/upcoming_statement.html
@@ -1,0 +1,1 @@
+If you would like to learn more or if you'd like to be notified when the application is open, please sign up <a href="https://docs.google.com/forms/d/e/1FAIpQLSf-HCWKQp_3TKJs0ss-3IqzbI0HY16rH5LnV8CRpIBykeH07g/viewform?usp=sf_link">here</a>.

--- a/_includes/upcoming_statement.md
+++ b/_includes/upcoming_statement.md
@@ -1,1 +1,0 @@
-If you would like to learn more or if you'd like to be notified when the application is open, please sign up [here](https://docs.google.com/forms/d/e/1FAIpQLSf-HCWKQp_3TKJs0ss-3IqzbI0HY16rH5LnV8CRpIBykeH07g/viewform?usp=sf_link).

--- a/_layouts/custom.html
+++ b/_layouts/custom.html
@@ -14,7 +14,7 @@ layout: page
 <div class="usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h3 class="usa-alert-heading">Upcoming role</h3>
-    <p class="usa-alert-text">This role is not yet open to apply to. See below for details.</p>
+    <p class="usa-alert-text">This role is not yet open to apply to. {% include upcoming_statement.html %}</p>
   </div>
 </div>
 {% elsif page.state == 'open' %}

--- a/_layouts/custom.html
+++ b/_layouts/custom.html
@@ -17,6 +17,13 @@ layout: page
     <p class="usa-alert-text">This role is not yet open to apply to. See below for details.</p>
   </div>
 </div>
+{% elsif page.state == 'open' %}
+<div class="usa-alert usa-alert-info">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Apply now!</h3>
+    <p class="usa-alert-text">This role is open for applications until {{ page.closes | date: '%A, %B %e, %Y at %l:%M%P %Z' }}.</p>
+  </div>
+</div>
 {% endif %}
 
 <h1>{{ page.title }}</h1>

--- a/_layouts/custom.html
+++ b/_layouts/custom.html
@@ -2,29 +2,5 @@
 layout: page
 ---
 
-{% if page.state == "closed" %}
-<div class="usa-alert usa-alert-warning">
-  <div class="usa-alert-body">
-    <h3 class="usa-alert-heading">This job posting has closed.</h3>
-    <p class="usa-alert-text">Please see
-      <a href="{{site.baseurl}}/#join-us">our other open positions</a>.</p>
-  </div>
-</div>
-{% elsif page.state == 'upcoming' %}
-<div class="usa-alert usa-alert-info">
-  <div class="usa-alert-body">
-    <h3 class="usa-alert-heading">Upcoming role</h3>
-    <p class="usa-alert-text">This role is not yet open to apply to. {% include upcoming_statement.html %}</p>
-  </div>
-</div>
-{% elsif page.state == 'open' %}
-<div class="usa-alert usa-alert-info">
-  <div class="usa-alert-body">
-    <h3 class="usa-alert-heading">Apply now!</h3>
-    <p class="usa-alert-text">This role is open for applications until {{ page.closes | date: '%A, %B %e, %Y at %l:%M%P %Z' }}.</p>
-  </div>
-</div>
-{% endif %}
-
 <h1>{{ page.title }}</h1>
 {{ content }}

--- a/_layouts/job.html
+++ b/_layouts/job.html
@@ -1,0 +1,30 @@
+---
+layout: page
+---
+
+{% if page.state == "closed" %}
+<div class="usa-alert usa-alert-warning">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">This job posting has closed.</h3>
+    <p class="usa-alert-text">Please see
+      <a href="{{site.baseurl}}/#join-us">our other open positions</a>.</p>
+  </div>
+</div>
+{% elsif page.state == 'upcoming' %}
+<div class="usa-alert usa-alert-info">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Upcoming role</h3>
+    <p class="usa-alert-text">This role is not yet open to apply to. {% include upcoming_statement.html %}</p>
+  </div>
+</div>
+{% elsif page.state == 'open' %}
+<div class="usa-alert usa-alert-info">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Apply now!</h3>
+    <p class="usa-alert-text">This role is open for applications until {{ page.closes | date: '%A, %B %e, %Y at %l:%M%P %Z' }}.</p>
+  </div>
+</div>
+{% endif %}
+
+<h1>{{ page.title }}</h1>
+{{ content }}

--- a/_layouts/job.html
+++ b/_layouts/job.html
@@ -28,3 +28,6 @@ layout: page
 
 <h1>{{ page.title }}</h1>
 {{ content }}
+
+{% capture apply %}{% include how_to_apply.md %}{% endcapture %}
+{{ apply | markdownify }}

--- a/pages/index.md
+++ b/pages/index.md
@@ -44,7 +44,7 @@ We’re looking for candidates passionate about our mission with top-notch softw
 {% for pg in sortedpages %}
 {% if pg.state == 'open' %}
 {% unless pg.path contains 'template'  %}
-* [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }})
+* [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }}) (Open now through {{ pg.closes | date: '%A, %B %e, %Y at %l:%M%P %Z' }})
 {% endunless %}
 {% endif %}
 {% endfor %}

--- a/pages/positions/18f-consulting-software-engineer-gs15.md
+++ b/pages/positions/18f-consulting-software-engineer-gs15.md
@@ -4,6 +4,9 @@ permalink: /join/consulting-software-engineer-gs15/
 redirect_from:
   - /join/consulting-software-engineer-gs15-closed/
 state: closed
+apply_url: https://goo.gl/forms/Kd68Qfq5ZukiPgrX2
+contact_name: Leigh Finkel
+contact_email: jointts@gsa.gov
 
 subnav:
   - text: Role summary
@@ -217,15 +220,5 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-## How To Apply
-
-Submit a complete online application prior to 8:00pm Eastern Time on the closing date of the posting. Please fill out all applicable fields.
-
-<section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://goo.gl/forms/Kd68Qfq5ZukiPgrX2">Click here to apply</a>
-</section>
-
-**Need Assistance in applying or have questions regarding this job opportunity, please email Leigh Finkel at** [jointts@gsa.gov](mailto:jointts@gsa.gov).
 
 {% include how_to_apply.md %}

--- a/pages/positions/18f-consulting-software-engineer-gs15.md
+++ b/pages/positions/18f-consulting-software-engineer-gs15.md
@@ -220,5 +220,3 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-{% include how_to_apply.md %}

--- a/pages/positions/18f-content-designer-gs15.md
+++ b/pages/positions/18f-content-designer-gs15.md
@@ -200,5 +200,3 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-{% include how_to_apply.md %}

--- a/pages/positions/18f-content-designer-gs15.md
+++ b/pages/positions/18f-content-designer-gs15.md
@@ -4,6 +4,9 @@ permalink: /join/18f-content-designer-gs15/
 redirect_from:
   - /join/18f-content-designer-gs15-closed/
 state: closed
+apply_url: https://goo.gl/forms/ZFr4NJJ5o7vcaXnI2
+contact_name: Liz Scott
+contact_email: jointts@gsa.gov
 
 subnav:
   - text: Role summary
@@ -197,15 +200,5 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-## How To Apply
-
-Submit a complete online application prior to 11:59 pm Eastern Time on the closing date of the posting. Please fill out all applicable fields.
-
-<section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://goo.gl/forms/ZFr4NJJ5o7vcaXnI2">Click here to apply</a>
-</section>
-
-**Need Assistance in applying or have questions regarding this job opportunity, please email Liz Scott at** [jointts@gsa.gov](mailto:jointts@gsa.gov).
 
 {% include how_to_apply.md %}

--- a/pages/positions/18f-product-manager-2-gs15.md
+++ b/pages/positions/18f-product-manager-2-gs15.md
@@ -3,6 +3,9 @@ title: Product Manager
 permalink: /join/18f-product-manager/
 state: open
 closes: June 8, 2018, 8:00pm EDT
+apply_url: https://goo.gl/forms/2W18A6443ePgVktq2
+contact_name: Leigh Finkel
+contact_email: jointts@gsa.gov
 
 subnav:
   - text: Role summary
@@ -234,15 +237,5 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-## How To Apply
-
-Submit a complete online application prior to 8:00pm Eastern Time on the closing date of the posting. To apply, click the link below and please fill out all applicable fields:
-
-<section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://goo.gl/forms/2W18A6443ePgVktq2">Click here to apply</a>
-</section>
-
-**Need Assistance in applying or have questions regarding this job opportunity, please email Leigh Finkel at** [jointts@gsa.gov](mailto:jointts@gsa.gov).
 
 {% include how_to_apply.md %}

--- a/pages/positions/18f-product-manager-2-gs15.md
+++ b/pages/positions/18f-product-manager-2-gs15.md
@@ -2,6 +2,7 @@
 title: Product Manager
 permalink: /join/18f-product-manager/
 state: open
+closes: June 8, 2018, 8:00pm EDT
 
 subnav:
   - text: Role summary

--- a/pages/positions/18f-product-manager-2-gs15.md
+++ b/pages/positions/18f-product-manager-2-gs15.md
@@ -237,5 +237,3 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-{% include how_to_apply.md %}

--- a/pages/positions/18f-product-manager-gs15.md
+++ b/pages/positions/18f-product-manager-gs15.md
@@ -4,6 +4,9 @@ permalink: /join/product-manager-gs15/
 redirect_from:
   - /join/product-manager-gs15-closed/
 state: closed
+apply_url: https://goo.gl/forms/cEKydjQ2zT0phKeh2
+contact_name: Leigh Finkel
+contact_email: jointts@gsa.gov
 
 subnav:
   - text: Role summary
@@ -218,15 +221,5 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year)
 - number of hours per week you worked (if part time).
-
-## How To Apply
-
-Submit a complete online application prior to 11:59 pm Eastern Time on the closing date of the posting. Please fill out all applicable fields.
-
-<section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://goo.gl/forms/cEKydjQ2zT0phKeh2">Click here to apply</a>
-</section>
-
-**Need Assistance in applying or have questions regarding this job opportunity, please email Leigh Finkel at** [joinTTS@gsa.gov](mailto:jointts@gsa.gov).
 
 {% include how_to_apply.md %}

--- a/pages/positions/18f-product-manager-gs15.md
+++ b/pages/positions/18f-product-manager-gs15.md
@@ -221,5 +221,3 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year)
 - number of hours per week you worked (if part time).
-
-{% include how_to_apply.md %}

--- a/pages/positions/18f-strategist-gs15.md
+++ b/pages/positions/18f-strategist-gs15.md
@@ -254,5 +254,3 @@ this information may result in disqualification.
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-{% include how_to_apply.md %}

--- a/pages/positions/18f-strategist-gs15.md
+++ b/pages/positions/18f-strategist-gs15.md
@@ -4,6 +4,9 @@ permalink: /join/strategist-gs15/
 redirect_from:
   - /join/strategist-gs15-closed/
 state: closed
+apply_url: https://docs.google.com/forms/d/e/1FAIpQLScnjWfF1WdddBlkXkHiCWqrGxvI-zeGScm80-DjdjEheXIATw/viewform
+contact_name: Elizabeth Scott
+contact_email: jointts@gsa.gov
 
 subnav:
   - text: Role summary
@@ -251,17 +254,5 @@ this information may result in disqualification.
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-## How To Apply
-
-Submit a complete online application prior to 11:59 pm Eastern Time on the closing date of the posting. Please fill out
-all applicable fields.
-
-<section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://docs.google.com/forms/d/e/1FAIpQLScnjWfF1WdddBlkXkHiCWqrGxvI-zeGScm80-DjdjEheXIATw/viewform">Click here to apply</a>
-</section>
-
-**Need Assistance in applying or have questions regarding this job opportunity, please email Elizabeth Scott
-at** [jointts@gsa.gov](mailto:jointts@gsa.gov).
 
 {% include how_to_apply.md %}

--- a/pages/positions/18f-upcoming-consulting-software-engineer-gs15.md
+++ b/pages/positions/18f-upcoming-consulting-software-engineer-gs15.md
@@ -18,8 +18,6 @@ subnav:
 
 18F will soon be accepting applications for the Consulting Software Engineer (GS15) role. This page includes basic information about the role, key objectives, required qualifications, as well as the competencies we will be using for evaluating applications.
 
-{% include upcoming_statement.md %}
-
 **Quick Links to Posting Sections**
 - [Basic information](#basic-information)
 - [Role summary](#role-summary)

--- a/pages/positions/18f-upcoming-consulting-software-engineer-gs15.md
+++ b/pages/positions/18f-upcoming-consulting-software-engineer-gs15.md
@@ -127,5 +127,3 @@ If found to be eligible and at least minimally qualified for the position, your 
 If your resume does not support your possession of the competencies listed above, we may lower your score, which could place you in a lower category.
 
 Within each category, veterans will receive selection priority over non-veterans if supported by appropriate documentation.
-
-{% include how_to_apply.md %}

--- a/pages/positions/18f-upcoming-consulting-software-engineer-gs15.md
+++ b/pages/positions/18f-upcoming-consulting-software-engineer-gs15.md
@@ -130,6 +130,4 @@ If your resume does not support your possession of the competencies listed above
 
 Within each category, veterans will receive selection priority over non-veterans if supported by appropriate documentation.
 
-## How To Apply
-
-{% include upcoming_statement.md %}
+{% include how_to_apply.md %}

--- a/pages/positions/18f-upcoming-product-manager-gs15.md
+++ b/pages/positions/18f-upcoming-product-manager-gs15.md
@@ -136,6 +136,4 @@ If your resume does not support your possession of the competencies listed above
 
 Within each category, veterans will receive selection priority over non-veterans if supported by appropriate documentation.
 
-## How To Apply
-
-{% include upcoming_statement.md %}
+{% include how_to_apply.md %}

--- a/pages/positions/18f-upcoming-product-manager-gs15.md
+++ b/pages/positions/18f-upcoming-product-manager-gs15.md
@@ -133,5 +133,3 @@ If found to be eligible and at least minimally qualified for the position, your 
 If your resume does not support your possession of the competencies listed above, we may lower your score, which could place you in a lower category.
 
 Within each category, veterans will receive selection priority over non-veterans if supported by appropriate documentation.
-
-{% include how_to_apply.md %}

--- a/pages/positions/18f-upcoming-product-manager-gs15.md
+++ b/pages/positions/18f-upcoming-product-manager-gs15.md
@@ -16,8 +16,6 @@ subnav:
 
 18F will soon be accepting applications for the Product Manager (GS15) role. This page includes basic information about the role, key objectives, required qualifications, as well as the competencies we will be using for evaluating applications.
 
-{% include upcoming_statement.md %}
-
 **Quick Links to Posting Sections**
 - [Basic information](#basic-information)
 - [Role summary](#role-summary)

--- a/pages/positions/18f-upcoming-ux-designer-gs15.md
+++ b/pages/positions/18f-upcoming-ux-designer-gs15.md
@@ -125,8 +125,4 @@ If your resume does not support your possession of the competencies listed above
 
 Within each category, veterans will receive selection priority over non-veterans if supported by appropriate documentation.
 
-## How To Apply
-
-This role will be open for application on **Monday, May 21, 2018 through Friday, May 25, 2018 at 8:00pm Eastern Time**. Apply online at <https://join.tts.gsa.gov/> during this application window.
-
-If you need assistance in applying or have questions regarding this job opportunity, please email Liz Scott at [jointts@gsa.gov](mailto:jointts@gsa.gov).
+{% include how_to_apply.md %}

--- a/pages/positions/18f-upcoming-ux-designer-gs15.md
+++ b/pages/positions/18f-upcoming-ux-designer-gs15.md
@@ -124,5 +124,3 @@ If found to be eligible and at least minimally qualified for the position, your 
 If your resume does not support your possession of the competencies listed above, we may lower your score, which could place you in a lower category.
 
 Within each category, veterans will receive selection priority over non-veterans if supported by appropriate documentation.
-
-{% include how_to_apply.md %}

--- a/pages/positions/18f-user-experience-designer-gs15.md
+++ b/pages/positions/18f-user-experience-designer-gs15.md
@@ -205,5 +205,3 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-{% include how_to_apply.md %}

--- a/pages/positions/18f-user-experience-designer-gs15.md
+++ b/pages/positions/18f-user-experience-designer-gs15.md
@@ -4,6 +4,9 @@ permalink: /join/18f-user-experience-designer-gs15/
 redirect_from:
   - /join/18f-user-experience-designer-gs15-closed/
 state: closed
+apply_url: https://docs.google.com/forms/d/e/1FAIpQLSeY1SlBbVoSJMJVpv64WqWGKM6WXbmvwBhoHpyCz4Efa_1gtQ/viewform
+contact_name: Liz Scott
+contact_email: jointts@gsa.gov
 
 subnav:
   - text: Role summary
@@ -202,15 +205,5 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-## How To Apply
-
-Submit a complete online application prior to 8:00 pm Eastern Time on the closing date of the posting. Please fill out all applicable fields.
-
-<section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://docs.google.com/forms/d/e/1FAIpQLSeY1SlBbVoSJMJVpv64WqWGKM6WXbmvwBhoHpyCz4Efa_1gtQ/viewform">Click here to apply</a>
-</section>
-
-**If you need assistance in applying or have questions regarding this job opportunity, please email Liz Scott at** [jointts@gsa.gov](mailto:jointts@gsa.gov).
 
 {% include how_to_apply.md %}

--- a/pages/positions/18f-ux-designer-gs14.md
+++ b/pages/positions/18f-ux-designer-gs14.md
@@ -4,6 +4,9 @@ permalink: /join/18f-ux-designer/
 redirect_from:
   - /join/18f-ux-designer-closed/
 state: closed
+apply_url: https://goo.gl/forms/7t0UmLkquhiTAET13
+contact_name: Amanda Schonfeld
+contact_email: jointts@gsa.gov
 
 subnav:
   - text: Role summary
@@ -255,16 +258,5 @@ this information may result in disqualification.
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-## How To Apply
-
-Submit a complete online application prior to 11:59 pm Eastern Time on the closing date of the posting. Please fill out all applicable fields.
-
-<section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://goo.gl/forms/7t0UmLkquhiTAET13">Click here to apply</a>
-</section>
-
-**Need Assistance in applying or have questions regarding this job opportunity, please email Amanda Schonfeld at**
-[jointts@gsa.gov](mailto:jointts@gsa.gov).
 
 {% include how_to_apply.md %}

--- a/pages/positions/18f-ux-designer-gs14.md
+++ b/pages/positions/18f-ux-designer-gs14.md
@@ -258,5 +258,3 @@ this information may result in disqualification.
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-{% include how_to_apply.md %}

--- a/pages/positions/18f-visual-designer-gs14.md
+++ b/pages/positions/18f-visual-designer-gs14.md
@@ -4,6 +4,9 @@ permalink: /join/18f-visual-designer/
 redirect_from:
   - /join/18f-visual-designer-closed/
 state: closed
+apply_url: https://goo.gl/forms/sscRglEbs6SwZdpo2
+contact_name: Liz Scott
+contact_email: jointts@gsa.gov
 
 subnav:
   - text: Role summary
@@ -205,15 +208,5 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-## How To Apply
-
-Submit a complete online application prior to 8:00 pm Eastern Time on the closing date of the posting. Please fill out all applicable fields.
-
-<section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://goo.gl/forms/sscRglEbs6SwZdpo2">Click here to apply</a>
-</section>
-
-**Need Assistance in applying or have questions regarding this job opportunity, please email Liz Scott at** [jointts@gsa.gov](mailto:jointts@gsa.gov).
 
 {% include how_to_apply.md %}

--- a/pages/positions/18f-visual-designer-gs14.md
+++ b/pages/positions/18f-visual-designer-gs14.md
@@ -208,5 +208,3 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-{% include how_to_apply.md %}

--- a/pages/positions/acq-user-experience-design-lead-gs15.md
+++ b/pages/positions/acq-user-experience-design-lead-gs15.md
@@ -4,6 +4,9 @@ permalink: /join/user-experience-design-lead-gs15/
 redirect_from:
   - /join/user-experience-design-lead-gs15-closed/
 state: closed
+apply_url: https://goo.gl/forms/yYPmtvXpsVlRZM0j2
+contact_name: Leigh Finkel
+contact_email: jointts@gsa.gov
 
 subnav:
   - text: Role summary
@@ -208,15 +211,5 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year)
 - number of hours per week you worked (if part time).
-
-## How To Apply
-
-Submit a complete online application prior to 11:59 pm Eastern Time on the closing date of the posting. Please fill out all applicable fields.
-
-<section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://goo.gl/forms/yYPmtvXpsVlRZM0j2">Click here to apply</a>
-</section>
-
-**Need Assistance in applying or have questions regarding this job opportunity, please email Leigh Finkel** [joinTTS@gsa.gov](mailto:joinTTS@gsa.gov).
 
 {% include how_to_apply.md %}

--- a/pages/positions/acq-user-experience-design-lead-gs15.md
+++ b/pages/positions/acq-user-experience-design-lead-gs15.md
@@ -211,5 +211,3 @@ Qualification determinations cannot be made when resumes do not include the requ
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year)
 - number of hours per week you worked (if part time).
-
-{% include how_to_apply.md %}

--- a/pages/positions/coe-upcoming-cloud-adoption-specialist-gs15.md
+++ b/pages/positions/coe-upcoming-cloud-adoption-specialist-gs15.md
@@ -18,8 +18,6 @@ subnav:
 
 The TTS Centers of Excellence (CoE) office is looking for someone to join their team as a Cloud Adoption Specialist (GS15). This page includes basic information about the role, the role summary and key objectives needed in order to perform the role well.
 
-{% include upcoming_statement.md %}
-
 **Quick Links to Posting Sections**
 - [Basic information](#basic-information)
 - [Role summary](#role-summary)

--- a/pages/positions/coe-upcoming-cloud-adoption-specialist-gs15.md
+++ b/pages/positions/coe-upcoming-cloud-adoption-specialist-gs15.md
@@ -77,6 +77,4 @@ No one can be equally expert on all phases of the cloud adoption process, but we
 - Serve as a liaison between the stakeholders and the project teams, delivering feedback to the team, enabling them to make necessary changes to product performance or presentation
 - Support a safe, inclusive workplace and a positive team culture where all team members value diversity and individual differences
 
-## How To Apply
-
-{% include upcoming_statement.md %}
+{% include how_to_apply.md %}

--- a/pages/positions/coe-upcoming-cloud-adoption-specialist-gs15.md
+++ b/pages/positions/coe-upcoming-cloud-adoption-specialist-gs15.md
@@ -74,5 +74,3 @@ No one can be equally expert on all phases of the cloud adoption process, but we
 - Skillfully map specific inquiries to product capabilities, identifying the product that best meets the agency partner’s needs.
 - Serve as a liaison between the stakeholders and the project teams, delivering feedback to the team, enabling them to make necessary changes to product performance or presentation
 - Support a safe, inclusive workplace and a positive team culture where all team members value diversity and individual differences
-
-{% include how_to_apply.md %}

--- a/pages/positions/coe-upcoming-contact-center-optimization-specialist-gs15.md
+++ b/pages/positions/coe-upcoming-contact-center-optimization-specialist-gs15.md
@@ -75,5 +75,3 @@ Develop and track performance metrics, customer feedback, quality assurance and 
 - Skillfully map specific inquiries to product capabilities, identifying the product that best meets the agency partner’s needs.
 - Serve as a liaison between the stakeholders and the project teams, delivering feedback to the team, enabling them to make necessary changes to product performance or presentation
 - Support a safe, inclusive workplace and a positive team culture where all team members value diversity and individual differences
-
-{% include how_to_apply.md %}

--- a/pages/positions/coe-upcoming-contact-center-optimization-specialist-gs15.md
+++ b/pages/positions/coe-upcoming-contact-center-optimization-specialist-gs15.md
@@ -17,8 +17,6 @@ subnav:
 The TTS Centers of Excellence (CoE) office is looking for someone to join their team as a Contact Center Optimization
 Specialist (GS15). This page includes basic information about the role, the role summary and key objectives needed in order to perform the role well.
 
-{% include upcoming_statement.md %}
-
 **Quick Links to Posting Sections**
 - [Basic information](#basic-information)
 - [Role summary](#role-summary)

--- a/pages/positions/coe-upcoming-contact-center-optimization-specialist-gs15.md
+++ b/pages/positions/coe-upcoming-contact-center-optimization-specialist-gs15.md
@@ -78,6 +78,4 @@ Develop and track performance metrics, customer feedback, quality assurance and 
 - Serve as a liaison between the stakeholders and the project teams, delivering feedback to the team, enabling them to make necessary changes to product performance or presentation
 - Support a safe, inclusive workplace and a positive team culture where all team members value diversity and individual differences
 
-## How To Apply
-
-{% include upcoming_statement.md %}
+{% include how_to_apply.md %}

--- a/pages/positions/coe-upcoming-customer-experience-specialist.md
+++ b/pages/positions/coe-upcoming-customer-experience-specialist.md
@@ -17,8 +17,6 @@ subnav:
 The TTS Centers of Excellence (CoE) office is looking for someone to join their team as a Customer Experience Specialist
 (GS15). This page includes basic information about the role, the role summary and key objectives needed in order to perform the role well.
 
-{% include upcoming_statement.md %}
-
 **Quick Links to Posting Sections**
 - [Basic information](#basic-information)
 - [Role summary](#role-summary)

--- a/pages/positions/coe-upcoming-customer-experience-specialist.md
+++ b/pages/positions/coe-upcoming-customer-experience-specialist.md
@@ -77,6 +77,4 @@ To be successful you’ll need consulting experience along with a background in 
 - Serve as a liaison between the stakeholders and the project teams, delivering feedback to the team, enabling them to make necessary changes to product performance or presentation
 - Support a safe, inclusive workplace and a positive team culture where all team members value diversity and individual differences
 
-## How To Apply
-
-{% include upcoming_statement.md %}
+{% include how_to_apply.md %}

--- a/pages/positions/coe-upcoming-customer-experience-specialist.md
+++ b/pages/positions/coe-upcoming-customer-experience-specialist.md
@@ -74,5 +74,3 @@ To be successful you’ll need consulting experience along with a background in 
 - Skillfully map specific inquiries to product capabilities, identifying the product that best meets the agency partner’s needs.
 - Serve as a liaison between the stakeholders and the project teams, delivering feedback to the team, enabling them to make necessary changes to product performance or presentation
 - Support a safe, inclusive workplace and a positive team culture where all team members value diversity and individual differences
-
-{% include how_to_apply.md %}

--- a/pages/positions/coe-upcoming-data-and-analytics-specialist.md
+++ b/pages/positions/coe-upcoming-data-and-analytics-specialist.md
@@ -73,5 +73,3 @@ Data & Analytics Specialists should not be theoreticians, but rather practitione
 - Skillfully map specific inquiries to product capabilities, identifying the product that best meets the agency partner’s needs.
 - Serve as a liaison between the stakeholders and the project teams, delivering feedback to the team, enabling them to make necessary changes to product performance or presentation
 - Support a safe, inclusive workplace and a positive team culture where all team members value diversity and individual differences
-
-{% include how_to_apply.md %}

--- a/pages/positions/coe-upcoming-data-and-analytics-specialist.md
+++ b/pages/positions/coe-upcoming-data-and-analytics-specialist.md
@@ -18,8 +18,6 @@ subnav:
 
 The TTS Centers of Excellence (CoE) office is looking for someone to join their team as a Data & Analytics Specialist (GS15). This page includes basic information about the role, the role summary and key objectives needed in order to perform the role well.
 
-{% include upcoming_statement.md %}
-
 **Quick Links to Posting Sections**
 - [Basic information](#basic-information)
 - [Role summary](#role-summary)

--- a/pages/positions/coe-upcoming-data-and-analytics-specialist.md
+++ b/pages/positions/coe-upcoming-data-and-analytics-specialist.md
@@ -76,6 +76,4 @@ Data & Analytics Specialists should not be theoreticians, but rather practitione
 - Serve as a liaison between the stakeholders and the project teams, delivering feedback to the team, enabling them to make necessary changes to product performance or presentation
 - Support a safe, inclusive workplace and a positive team culture where all team members value diversity and individual differences
 
-## How To Apply
-
-{% include upcoming_statement.md %}
+{% include how_to_apply.md %}

--- a/pages/positions/coe-upcoming-infrastructure-optimization-specialist.md
+++ b/pages/positions/coe-upcoming-infrastructure-optimization-specialist.md
@@ -16,8 +16,6 @@ subnav:
 
 The TTS Centers of Excellence (CoE) office is looking for someone to join their team as a Infrastructure Optimization Specialist(GS15). This page includes basic information about the role, the role summary and key objectives needed in order to perform the role well.
 
-{% include upcoming_statement.md %}
-
 **Quick Links to Posting Sections**
 - [Basic information](#basic-information)
 - [Role summary](#role-summary)

--- a/pages/positions/coe-upcoming-infrastructure-optimization-specialist.md
+++ b/pages/positions/coe-upcoming-infrastructure-optimization-specialist.md
@@ -78,5 +78,3 @@ You will need a thorough knowledge of infrastructure, networking, cloud, integra
 - Skillfully map specific inquiries to product capabilities, identifying the product that best meets the agency partner’s needs.
 - Serve as a liaison between the stakeholders and the project teams, delivering feedback to the team, enabling them to make necessary changes to product performance or presentation
 - Support a safe, inclusive workplace and a positive team culture where all team members value diversity and individual differences
-
-{% include how_to_apply.md %}

--- a/pages/positions/coe-upcoming-infrastructure-optimization-specialist.md
+++ b/pages/positions/coe-upcoming-infrastructure-optimization-specialist.md
@@ -81,6 +81,4 @@ You will need a thorough knowledge of infrastructure, networking, cloud, integra
 - Serve as a liaison between the stakeholders and the project teams, delivering feedback to the team, enabling them to make necessary changes to product performance or presentation
 - Support a safe, inclusive workplace and a positive team culture where all team members value diversity and individual differences
 
-## How To Apply
-
-{% include upcoming_statement.md %}
+{% include how_to_apply.md %}

--- a/pages/positions/pif-presidential-innovation-fellow-gs15.md
+++ b/pages/positions/pif-presidential-innovation-fellow-gs15.md
@@ -3,6 +3,9 @@ title: Presidential Innovation Fellow
 permalink: /join/pif-presidential-innovation-fellow/
 state: open
 closes: June 24, 2018, 11:59pm EDT
+apply_url: https://apply.pif.gov/
+contact_name: Deb Baptiste
+contact_email: jointts@gsa.gov
 
 subnav:
   - text: Role summary
@@ -298,17 +301,5 @@ information may result in disqualification.
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-## How To Apply
-
-Submit a complete online application prior to 11:59 pm Eastern Time on the closing date of the posting. Please fill out
-all applicable fields.
-
-<section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://apply.pif.gov/">Click here to apply</a>
-</section>
-
-**If you need assistance in applying or have questions regarding this job opportunity, please email Deb Baptiste at
-[jointts@gsa.gov](mailto:jointts@gsa.gov).**
 
 {% include how_to_apply.md %}

--- a/pages/positions/pif-presidential-innovation-fellow-gs15.md
+++ b/pages/positions/pif-presidential-innovation-fellow-gs15.md
@@ -2,6 +2,7 @@
 title: Presidential Innovation Fellow
 permalink: /join/pif-presidential-innovation-fellow/
 state: open
+closes: June 24, 2018, 11:59pm EDT
 
 subnav:
   - text: Role summary

--- a/pages/positions/pif-presidential-innovation-fellow-gs15.md
+++ b/pages/positions/pif-presidential-innovation-fellow-gs15.md
@@ -301,5 +301,3 @@ information may result in disqualification.
 For each job on your resume, provide:
 - the exact dates you held each job (from month/year to month/year or “present”)
 - number of hours per week you worked (if part time)
-
-{% include how_to_apply.md %}

--- a/pages/positions/template_upcoming-position.md
+++ b/pages/positions/template_upcoming-position.md
@@ -3,6 +3,9 @@ title: TITLE
 permalink: join/OFFICE-ROLE-GS LEVEL/
 state: upcoming
 # closes: MONTH DAY, YEAR, TIME EDT
+# apply_url: URL
+# contact_name: NAME
+contact_email: jointts@gsa.gov
 
 subnav:
  - text: Basic information

--- a/pages/positions/template_upcoming-position.md
+++ b/pages/positions/template_upcoming-position.md
@@ -2,6 +2,7 @@
 title: TITLE
 permalink: join/OFFICE-ROLE-GS LEVEL/
 state: upcoming
+# closes: MONTH DAY, YEAR, TIME EDT
 
 subnav:
  - text: Basic information

--- a/pages/positions/template_upcoming-position.md
+++ b/pages/positions/template_upcoming-position.md
@@ -94,16 +94,4 @@ Specialized experience is:
 
 ENTER SE THAT WILL BE ON JOB ANNONOUCEMENT SENT TO HR
 
-## How To Apply
-
-This role will be open for application on **Monday, DATE, through Friday, DATE, 2018 at 8:00pm Eastern Time**.
-Apply online at <https://join.tts.gsa.gov/> during this application window.
-
-If you need assistance in applying or have questions regarding this job opportunity, please email RECRUITER NAME at
-[jointts@gsa.gov](mailto:jointts@gsa.gov).
-
-OR
-
-We are currently not acceping applications at this time.
-
-{% include upcoming_statement.md %}
+{% include how_to_apply.md %}

--- a/pages/positions/template_upcoming-position.md
+++ b/pages/positions/template_upcoming-position.md
@@ -93,5 +93,3 @@ To qualify for this role, you must have one year of specialized experience equiv
 Specialized experience is:
 
 ENTER SE THAT WILL BE ON JOB ANNONOUCEMENT SENT TO HR
-
-{% include how_to_apply.md %}


### PR DESCRIPTION
Builds on #92.

Rather than having to put in the proper `include` based on whether the job is open or upcoming, this pull request makes it so that the "How to Apply" information is appropriate based on the `state`. Adds some new fields to the page metadata to be able to support it, but this should make job postings more consistent. Let me know what you think!