### PR TITLE
[WIP] Reorganize hiring process and resume content

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,9 @@
 primary:
   - text: Home
     href: /
-  - text: TTS Offices
+  - text: TTS offices
     href: /tts-offices/
-  - text: Hiring Process
+  - text: Hiring process
     href: /hiring-process/
+  - text: Preparing your resume
+    href: /preparing-your-resume/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -7,3 +7,5 @@ primary:
     href: /hiring-process/
   - text: Preparing your resume
     href: /preparing-your-resume/
+  - text: Compensation and benefits
+    href: /compensation-and-benefits/

--- a/pages/compensation-and-benefits.md
+++ b/pages/compensation-and-benefits.md
@@ -1,0 +1,46 @@
+---
+title: Compensation and benefits
+permalink: compensation-and-benefits/
+
+subnav:
+  - text: Government pay grades
+    href: "#government-pay-grades"
+  - text: Understanding grade levels
+    href: "#understanding-grade-levels"
+  - text: Raises and bonuses
+    href: "#raises-and-bonuses"
+  - text: Benefits and leave
+    href: "#benefits-and-leave"
+---
+
+## Government pay grades
+TTS team members are hired for specific position descriptions at a specific grade level from the federal general schedule (GS) (excluding SES positions). The GS system is a pay system for civilian employees in the federal government; evaluation and compensation varies by grade level. The qualification requirements for each position at a specific GS level are based on education, background, accomplishments, and experience. The specific requirements will always be listed in the job posting. Salaries of federal employees are public information, and your salary may become publicly available on sites like [FederalPay.org](https://www.federalpay.org/employees).
+
+## Understanding grade levels
+Federal employees on the general schedule range from GS-1 to GS-15. Find out more about the GS system from the [Office of Personnel Management](https://www.opm.gov/policy-data-oversight/pay-leave/pay-systems/general-schedule/).
+
+GS grade levels specify a fixed compensation range for a particular position, in particular geographic localities, within the federal government. Understanding the relationship between GS grade level, location, and compensation is important to understanding how salaries work at TTS.
+
+Each GS grade level contains a series of 10 steps. New employees are usually hired at Step 1 of a GS grade. However, in special circumstances, agencies may authorize a higher step rate for a newly-appointed federal employee based on a [special need of the agency or superior qualifications of the prospective employee](https://www.opm.gov/policy-data-oversight/pay-leave/pay-administration/fact-sheets/superior-qualifications-and-special-needs-pay-setting-authority/).
+
+The annual salary cap for all GS employees is $164,200 per year. You cannot be offered more than this under any circumstance.
+
+### General Schedule (GS) Salary Calculator
+Use this [OPM General Schedule (GS) Salary Calculator](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2017/general-schedule-gs-salary-calculator/) to help you understand how GS level, step, and locality affect compensation.
+
+## Raises and bonuses
+A step increase is the most common kind of raise for GS employees, and the amount of time between step increases is dependent on the step. As a GS employee, you have to wait one year to increase to a step 2, 3, or 4. Similarly, you must wait two years before increasing to step 5, 6, or 7. Lastly, you must wait three years before increasing to step 8, 9, or 10.  This means that if you join TTS at step 1, you’ll proceed to step 2 the following year. If you join TTS at step 6, it will take two years to progress to step 7.
+
+Bonuses generally come after the year-end review process in November and are awarded based on your performance review results. You must be a TTS employee for at least three months to get a performance review. Bonuses are either a small percentage of your annual salary or additional paid time off.
+
+## Benefits and leave
+The benefits package for federal employees includes medical, vision, and dental insurance, FSA accounts, life insurance, paid leave, and the Thrift Savings Plan (the government version of a 401K) with up to five percent matching. Our telework policy affords increased flexibility, and employees who use public transit to commute may claim commuter benefits.
+
+TTS also supports employees’ ongoing professional development by providing training opportunities and encouraging employees to participate in conferences, consortia, and other industry events.
+
+The [TTS Handbook](https://handbook.18f.gov/) has more information about working at TTS, including:
+
+- [Benefits](https://handbook.18f.gov/benefits/)
+- [Leave](https://handbook.18f.gov/benefits/#leave)
+- [Telework and virtual worker policy](https://handbook.18f.gov/telework/)
+- [Professional development and training processes](https://handbook.18f.gov/professional-development-and-training/#speaking-at-conferences)

--- a/pages/hiring-process.md
+++ b/pages/hiring-process.md
@@ -3,90 +3,30 @@ title: Hiring Process
 permalink: hiring-process/
 
 subnav:
-  - text: How we hire
-    href: "#how-we-hire"
-  - text: Eligibility
-    href: "#eligibility"
-  - text: Compensation and benefits
-    href: "#compensation-and-benefits"
+  - text: Timeline
+    href: "#process-timeline"
   - text: Application
     href: "#application"
-  - text: Government-style resume
-    href: "#government-style-resumes"
   - text: Interviews
     href: "#interviews"
   - text: Security and onboarding
     href: "#security-and-onboarding"
 ---
 
-## Intro
+The federal hiring process can often be confusing. The information below is intended to provide an overview of the process and help with understanding how to apply to an opportunity within TTS.
 
-The federal hiring process can be confusing and overwhelming. The information below is intended to provide an overview of the process and help with understanding how to apply to an opportunity within TTS.
-
-**Process Timeline**
+## Process timeline
 
 Hiring within the federal government takes more time than the typical private sector hiring process. Below is an example timeline based on our historic performance that should help you understand what to expect.
 
-|Process Stage | Avg Duration (Days) |
-|--:|:-:|
+| Stage | Avg. Duration (days) |
+|:--|:-:|
 | [Application](#application) collection | 5 |
 | TTS application review | 5 |
 | GSA HR application review | 10 |
 | [Interviews](#interviews) | 30 |
 | [Offer & security](#security-and-onboarding) | 30 to 60 |
-| **Total from Application to Start** | **80 to 110** |
-
-**TTS is an equal opportunity employer**
-
-We’re building a team that reflects the United States. We don’t discriminate based on race, color, religion, sex, gender identity or expression, national origin, political affiliation, sexual orientation, marital status, disability, genetic information, age, membership in an employee organization, retaliation, parental status, military service, or other non-merit factors.
-
-## How we hire
-There are three types of [hiring authorities](https://www.usajobs.gov/Help/working-in-government/service/) used by TTS: Competitive Service, Excepted Service, and Senior Executive Service. The application and hiring process will vary slightly based on the type of role you apply for.
-
-**Competitive Service:** All competitive service roles must be applied to by completing the application process at usajobs.gov. Individuals go through a competitive hiring process before being selected and appointed. This process is open to all applicants. Competitive service roles are considered “career roles,” which means they are not limited to a specific period of time or term. This hiring process may consist of a written test, an evaluation of the individual's education and experience, or an evaluation of other attributes necessary for successful performance in the position to be filled.
-
-**Excepted Service:** These roles are “not to exceed” (NTE) positions, which means they are two-year terms and can be extended once, for a total of four years of service. These roles are not required to be posted on usajobs.gov. Instead, candidates can apply via our online application.
-
-**Senior Executive Service (SES):** Very few of our positions are considered to be Senior Executive Service (SES) positions. These are Executive Director type roles classified above the general schedule (GS) grade 15 and can be excepted service or competitive service (see definitions above).
-
-## Eligibility
-For **Competitive Service** roles: All United States citizens and nationals (residents of American Samoa and Swains Islands) are eligible to apply.
-
-For **Excepted Service** roles: All United States citizens and nationals (residents of American Samoa and Swains Islands) and applicants must not be current GSA employees or contractors.
-
-## Compensation and benefits
-
-### Government pay grades
-TTS team members are hired for specific position descriptions at a specific grade level from the federal general schedule (GS) (excluding SES positions). The GS system is a pay system for civilian employees in the federal government; evaluation and compensation varies by grade level. The qualification requirements for each position at a specific GS level are based on education, background, accomplishments, and experience. The specific requirements will always be listed in the job posting. Salaries of federal employees are public information, and your salary may become publicly available on sites like [FederalPay.org](https://www.federalpay.org/employees).
-
-### Understanding grade levels
-Federal employees on the general schedule range from GS-1 to GS-15. Find out more about the GS system from the [Office of Personnel Management](https://www.opm.gov/policy-data-oversight/pay-leave/pay-systems/general-schedule/).
-
-GS grade levels specify a fixed compensation range for a particular position, in particular geographic localities, within the federal government. Understanding the relationship between GS grade level, location, and compensation is important to understanding how salaries work at TTS.
-
-Each GS grade level contains a series of 10 steps. New employees are usually hired at Step 1 of a GS grade. However, in special circumstances, agencies may authorize a higher step rate for a newly-appointed federal employee based on a [special need of the agency or superior qualifications of the prospective employee](https://www.opm.gov/policy-data-oversight/pay-leave/pay-administration/fact-sheets/superior-qualifications-and-special-needs-pay-setting-authority/).
-
-The annual salary cap for all GS employees is $164,200 per year. You cannot be offered more than this under any circumstance.
-
-### General Schedule (GS) Salary Calculator
-Use this [OPM General Schedule (GS) Salary Calculator](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2017/general-schedule-gs-salary-calculator/) to help you understand how GS level, step, and locality affect compensation.
-
-### Raises and bonuses
-A step increase is the most common kind of raise for GS employees, and the amount of time between step increases is dependent on the step. As a GS employee, you have to wait one year to increase to a step 2, 3, or 4. Similarly, you must wait two years before increasing to step 5, 6, or 7. Lastly, you must wait three years before increasing to step 8, 9, or 10.  This means that if you join TTS at step 1, you’ll proceed to step 2 the following year. If you join TTS at step 6, it will take two years to progress to step 7.
-
-Bonuses generally come after the year-end review process in late September and are awarded based on your performance review results. You must be a TTS employee for at least three months to get a performance review. Bonuses are either a small percentage of your annual salary or additional paid time off.
-
-### Benefits and leave
-The benefits package for federal employees includes medical, vision, and dental insurance, FSA accounts, life insurance, paid leave, and the Thrift Savings Plan (the government version of a 401K) with up to five percent matching. Our telework policy affords increased flexibility, and employees who use public transit to commute may claim commuter benefits.
-
-TTS also supports employees’ ongoing professional development by providing training opportunities and encouraging employees to participate in conferences, consortia, and other industry events.
-
-The [TTS Handbook](https://handbook.18f.gov/) has more information about working at TTS, including:
-
-- [Benefits](https://handbook.18f.gov/benefits/)
-- [Leave](https://handbook.18f.gov/benefits/#leave)
-- [Telework and virtual worker policy](https://handbook.18f.gov/telework/)
-- [Professional development and training processes](https://handbook.18f.gov/professional-development-and-training/#speaking-at-conferences)
+| **Total from application to start** | **80 to 110** |
 
 ## Application
 When you apply for a role at TTS, you’ll need to submit a [government-style resume]({{site.baseurl}}/hiring-process/#government-style-resumes), which includes much more detail than a private-sector resume.
@@ -94,106 +34,27 @@ When you apply for a role at TTS, you’ll need to submit a [government-style re
 [Veterans’ Preference](https://www.fedshirevets.gov/job-seekers/veterans-preference/) is applied for candidates who are veterans and have claimed their veteran status.
 
 ### How we collect and review applications
-We collect applications during the period specified in the job posting. After the application window has closed (generally within 7-14 days), we review and evaluate all applications at the same time. The way we collect and review applications depends on the role and the type of hiring authority being used.
+We collect applications during the period specified in the Basic Information section of each job posting. After the application window has closed (generally within 7-14 days), we review and evaluate all applications at the same time. The way we collect and review applications depends on the role and the type of hiring authority we're using.
 
 **Competitive Service:** Applications are collected via usajobs.gov and reviewed by the General Services Administration (GSA) Human Resources team, our parent federal agency’s human resources office.
 
 **Excepted Service:** Applications are collected via the postings within the TTS Join Page. All applications are reviewed by a panel of subject matter experts using a qualification process called [Category Rating](https://www.opm.gov/policy-data-oversight/hiring-information/competitive-hiring/#url=Category-Rating). Once we’ve evaluated all applications for a particular job posting, we send all of the applications and evaluation scores to GSA Human Resources for review.
 
-## Government-style resumes
-
-Unlike private-sector resumes, government-style resumes are often several pages long and include detailed information about the jobs you've held, your responsibilities, and what you accomplished.
-
-### General recommendations
-
-- When you are preparing your application, be sure to reference the Qualifications & Evaluation sections of the job post to help you best frame your experience.
-- Don’t get hung up on trying to match specific formatting just make sure you’ve included the information relevant to each section.
-- Be as detailed as possible, length is not an issue as long as the information you are including is relevant.
-- For your most relevant, recent, or longest held position, list 8-10 bullet points about your responsibilities and accomplishments. For each prior position, you can list fewer points focusing on the information that is most relevant to the job you are applying to.
-- Don’t be afraid to use technical terminology if it’s relevant to your role or the role you are applying to but avoid acronyms and abbreviations where possible.
-- We don’t use any kind of automated screening tools, your application will be evaluated by humans who will have varying levels of familiarity with the details of the roles. Although it’s not a key-word search, better to be explicit and not assume the reader has the domain knowledge or context to “read between the lines”.
-- Quantify as much as possible (where applicable)
-
-### Sample Structure/Key Information for each position
-
-This is the information that you should include for each position on your resume.
-- Company/Organization Name
-- Size of organization (x,xxx employees)
-- Location (City, State)
-- Dates of employment (MM/YYYY)
-- Hours Per Week (e.g. 15, 20, 40. If “full time” list 40 hours)
-- Job Title/Position Title
-- GS Level (Only relevant to current or past federal employees)
-- Brief description of the organization
-- Brief description of the product/project/team you worked on or supported (if applicable).
-- List of relevant skills, tools, technologies used
-- Specific duties, responsibilities, accomplishments of the position
-
-### Detailed Description of Sections
-
-#### Brief Description of the organization & Brief description of the product/project/team you worked on or supported (if applicable).
-
-This section provides context for your work and accomplishments which helps us understand how it’s applicable to our work and the role you are applying for. Examples of the kind of information on team, project, product, etc to include:
-- Clients/Customers type: public facing, end-users, internal, B2B, civic tech, etc
-- Scope of impact/Performance metrics: users, clients, datasets, uptime, cycle time, etc.
-- Team size/composition
-
-#### Relevant Skills, Tools, Technologies Used
-
-Here is where you will capture the skills, methodologies, techniques and tools that you used in that position. Focus on those things that were significant to your work and are relevant to the role that you are applying to. Below are some examples of things that you might include:
-- Scrum, Scaled Agile Framework, paired-programming, test-driven development, contextual inquiry, ethnograph, Lean startup
-- Wireframes, sitemaps, card sorting, storyboards, journey maps, proto-typing, roadmaps, style guides, pattern libraries, A/B testing, continuous integration
-- Information architecture, service design, visual design, content design, project management, copywriting, server-side development, front end development, containerization, configuration management,infrastructure automation
-- Axure, Powerpoint, Trello, Amazon Web Services, Azure, Docker, Slack, Github, Ruby, Mercurial, PyUnit, JUnit, Rspec, Travis, MongoDB, Redis, Cassandra
-
-### Example Resume Excerpt
-
-**Technology Transformation Services - Washington, DC - (300 employees)**
-
-_The Technology Transformation Services' (TTS) mission is to lead the digital transformation of the federal government by helping agencies build, buy, and share technology that allows them to provide more accessible, efficient, and effective products and services to the American people._
-
-**Software Engineer - 07/2015 to Present** - Hours per week: 40
-
-_Developer for USAJobs which is a job posting and application collection portal used by over 500 offices/agencies posting 320k jobs and over 10M applicant accounts_
-
-**Technical Skills Used:** Javascript, Docker, Node.js, Git, Postgres, test-driven development, scrum, Ruby on Rails, Postgres/PostGIS SQL,JSON,Redis, Heroku, Amazon Web Services (AWS), RESTful API, Rspec, CircleCi
-
-- Led and managed backend web development, support and deployment of USAJobs providing metrics and analytics dashboards
-- Developed new features and provided technical support solutions utilizing the Ruby on Rails framework, Postgres/PostGIS SQL, JSON and Redis while maintaining and deploying to Heroku, Amazon Web Services (AWS) cloud technologies including Relational Database Services (RDS) and Elastic Search environments
-- Partnered with departments gathering requirements to develop a joint implementation strategy, obtain access relevant agency internal data systems and data definitions and extract departmental datasets via RESTful APIs.
-- During implementation process met with agency stakeholders weekly to iterate using an Agile development approach to achieve a user centric designed experience
-- Managed codebase in GitHub repository for source control, scoping technical requirements into developmental milestones, releases tagging, issue tracking and source control.
-- Assembled with sales team, database administrators, product managers, data scientists, executive leadership, enterprise architects to form cross-functional, multidisciplinary team to develop a user focused analytics dashboard delivering an insightful analytics dashboard enabling government officials to make data driven decisions
-- Automated testing of codebase using Rspec and CircleCi for continuous integration
-- Guided team members on data infrastructure to implement front end solutions and peer review code commits for potential refactorization to ensure quality
-
-### Other sections to include, if applicable
-
-- Volunteer work (include the organization's name, your years of participation, and a one-line description of your role)
-- Relevant awards (include awarding organization, title of award, year received, and any relevant details, such as chosen as *award winner out of 300 contenders*)
-- Relevant public speaking engagements and presentations (include title of presentation, name of conference/event, month and year of presentation, and any other relevant details)
-- Certifications (name of certificate, institution issuing the certificate, year issued)
-- Relevant professional affiliations (organization name, your years of participation)
-- Publications (including personal blog posts) (title of published work, month and year of publication)
-- Training and courses (name of training or course, organization providing the training, MM/YYYY completed)
-
 ## Interviews
-The interview process typically takes about 2-3 weeks from the initial phone screen to a formal interview. The process usually begins with a 30-minute preliminary screening by phone or video call. Plan to briefly talk about your skills and experience and what you’re passionate about. We’ll share more about the role, our teams and the work we do during our conversation with you.
+The interview process typically takes about 2-3 weeks from the initial phone screen to a formal interview. The process usually begins with a 30-minute preliminary screening by phone or video call. Plan to briefly talk about your skills, experience, and what you’re passionate about. We’ll share more about the role, our teams, and our work.
 
-If we think you could be a good fit for the role you applied to, we’ll invite you to a series of formal video interviews with TTS team members. It’s during these longer conversations that we’ll discuss your past work experience in addition to the skills and knowledge that you can bring with you to TTS.
-
-If TTS identifies you as a strong candidate after interviews are completed, a TTS recruiter will reach out to you with next steps.
+If we think you could be a good fit for the role you applied to, we’ll invite you to a series of formal video interviews with TTS team members. It’s during these longer conversations that we’ll discuss your past work experience in addition to the skills and knowledge that you can bring with you to TTS. If TTS identifies you as a strong candidate, a TTS recruiter will reach out to you with next steps.
 
 See the [18F Engineering Hiring Guide](https://eng-hiring.18f.gov/) for more details on the process for those positions.
 
 ## Security and onboarding
-The hiring process continues in partnership with the GSA Human Resources team, our parent federal agency’s human resources office. They’re responsible for extending tentative and official final offers. The process is as follows:
+The hiring process continues in partnership with the GSA Human Resources team. They’re responsible for extending tentative and official final offers. Here's the process:
 
-- A GSA HR specialist will call you with a tentative offer.  “Tentative” means the offer is contingent on a security clearance. This offer will include salary for your consideration.
-  - **Please note: This is only a tentative offer, do not give notice, resign, etc from your current employer until you recieve the final offer with a confirmed start dated from HR.**
-- Once you have accepted the tentative offer, you will receive a USAccess email to schedule a time to provide your fingerprints at [one of these locations](http://www.fedidcard.gov/centerlocator.aspx) for your security clearance.
+- A GSA HR specialist will call you with a tentative offer. “Tentative” means the offer is contingent on a security clearance. This offer will include salary for your consideration.
+  - **Please note: This is only a tentative offer, do not give notice, resign, etc from your current employer until you receive the final offer with a confirmed start dated from HR.**
+- Once you've accepted the tentative offer, you will receive a USAccess email to schedule a time to provide your fingerprints at [one of these locations](http://www.fedidcard.gov/centerlocator.aspx) for your security clearance.
 - You will schedule and complete your fingerprint scans.
-- You will complete the [e-QIP questionnaire](https://www.opm.gov/investigations/e-qip-application/) for which you will need to provide your past seven years of employment and location history as well as information for individuals who can provide verifications of your employment and location history. We **strongly encourage** you to keep a digital or printed copy of the completed eQip for use during your interview with the background investigator.
+- You will complete the [e-QIP questionnaire](https://www.opm.gov/investigations/e-qip-application/) for which you will need to provide your past seven years of employment and location history as well as information for individuals who can provide verifications of your employment and location history. We **strongly encourage** you to keep a digital or printed copy of the completed e-QIP for use during your interview with the background investigator.
 - Once your e-QIP has been initially cleared, you will receive an interim security clearance and a GSA HR specialist will call you with a final offer.
 - GSA HR and the TTS Talent team will work with you to identify and set a start date. New employees start every other Monday on the first day of a GSA pay period.
 

--- a/pages/preparing-your-resume.md
+++ b/pages/preparing-your-resume.md
@@ -1,0 +1,89 @@
+---
+title: Preparing your resume
+permalink: preparing-your-resume/
+
+subnav:
+  - text: General recommendations
+    href: "#general-recommendations"
+  - text: Key information for each section
+    href: "#key-information-for-each-position"
+  - text: Example resume excerpt
+    href: "#example-resume-excerpt"
+  - text: Other sections to include
+    href: "#other-sections-to-include-if-applicable"
+---
+
+Unlike private-sector resumes, government-style resumes are often several pages long and include detailed information about the jobs you've held, your responsibilities, and what you accomplished.
+
+## General recommendations
+
+- When you're preparing your application, be sure to reference the Qualifications & Evaluation sections of the job post to help you best frame your experience.
+- Don’t get hung up on trying to match specific formatting. Just make sure you’ve included the information relevant to each section.
+- Be as detailed as possible. Length is not an issue as long as the information you include is relevant.
+- For your most relevant, recent, or longest held position, list 8-10 bullet points about your responsibilities and accomplishments. For each prior position, you can list fewer points focusing on the information that is most relevant to the job you are applying to.
+- Don’t be afraid to use technical terminology if it’s relevant to your role or the role you are applying to but avoid acronyms and abbreviations where possible.
+- We don’t use any kind of automated screening tools. Your application will be evaluated by humans who will have varying levels of familiarity with the details of the roles. Although it’s not a key-word search, it's better to be explicit and not assume the reader has the domain knowledge or context to “read between the lines”.
+- Quantify as much as possible
+
+## Key information for each position
+
+This is the information that you should include for each position on your resume.
+- Company/Organization Name
+- Size of organization (x,xxx employees)
+- Location (City, State)
+- Dates of employment (MM/YYYY)
+- Hours Per Week (15, 20, 40. If “full time” list 40 hours)
+- Job Title/Position Title
+- GS Level (Only relevant to current or past federal employees)
+- Brief description of the organization
+- Brief description of the product/project/team you worked on or supported (if applicable)
+- List of relevant skills, tools, and technologies used
+- Specific duties, responsibilities, and accomplishments of the position
+
+## Detailed Description of Sections
+
+### Brief description of the organization & Brief description of the product/project/team you worked on or supported (if applicable)
+
+This section provides context for your work and accomplishments, which helps us understand how it’s applicable to our work and the role you're applying for. Examples of information to include:
+- Client/Customer type: public facing, end-users, internal, B2B, civic tech, etc.
+- Scope of impact/Performance metrics: users, clients, datasets, uptime, cycle time, etc.
+- Team size/composition
+
+### Relevant skills, tools, and technologies used
+
+Here is where you will capture the skills, methodologies, techniques, and tools that you used in that position. Focus on those things that were significant to your work and are relevant to the role that you're applying to. For example:
+- Scrum, Scaled Agile Framework, paired-programming, test-driven development, contextual inquiry, ethnograph, Lean startup
+- Wireframes, sitemaps, card sorting, storyboards, journey maps, prototyping, roadmaps, style guides, pattern libraries, A/B testing, continuous integration
+- Information architecture, service design, visual design, content design, project management, copywriting, server-side development, front end development, containerization, configuration management, infrastructure automation
+- Axure, Powerpoint, Trello, Amazon Web Services, Azure, Docker, Slack, GitHub, Ruby, Mercurial, PyUnit, JUnit, Rspec, Travis, MongoDB, Redis, Cassandra
+
+## Example resume excerpt
+
+**Technology Transformation Services - Washington, DC - (300 employees)**
+
+_The Technology Transformation Services' (TTS) mission is to lead the digital transformation of the federal government by helping agencies build, buy, and share technology that allows them to provide more accessible, efficient, and effective products and services to the American people._
+
+**Software Engineer - 07/2015 to Present** - Hours per week: 40
+
+_Developer for USAJobs which is a job posting and application collection portal used by over 500 offices/agencies posting 320,000 jobs and over 10 million applicant accounts_
+
+**Technical Skills Used:** Javascript, Docker, Node.js, Git, Postgres, test-driven development, scrum, Ruby on Rails, Postgres/PostGIS SQL, JSON, Redis, Heroku, Amazon Web Services (AWS), RESTful API, Rspec, CircleCi
+
+- Led and managed backend web development, support, and deployment of USAJobs providing metrics and analytics dashboards
+- Developed new features and provided technical support solutions utilizing the Ruby on Rails framework, Postgres/PostGIS SQL, JSON, and Redis while maintaining and deploying to Heroku, Amazon Web Services (AWS) cloud technologies including Relational Database Services (RDS) and Elastic Search environments
+- Partnered with departments gathering requirements to develop a joint implementation strategy, obtain access to relevant agency internal data systems and data definitions, and extract departmental datasets via RESTful APIs.
+- During implementation process met with agency stakeholders weekly to iterate using an Agile development approach to achieve a user centric designed experience
+- Managed codebase in GitHub repository for source control, scoping technical requirements into developmental milestones, releases tagging, and issue tracking.
+- Assembled sales team, database administrators, product managers, data scientists, executive leadership, and enterprise architects to form cross-functional, multidisciplinary team to develop a user focused analytics dashboard delivering an insightful analytics dashboard enabling government officials to make data driven decisions
+- Automated testing of codebase using Rspec and CircleCi for continuous integration
+- Guided team members on data infrastructure to implement front end solutions and peer review code commits for potential refactorization to ensure quality
+
+## Other sections to include, if applicable
+
+- Volunteer work (include the organization's name, your years of participation, and a one-line description of your role)
+- Relevant awards (include awarding organization, title of award, year received, and any relevant details, such as *chosen as award winner out of 300 contenders*)
+- Relevant public speaking engagements and presentations (include title of presentation, name of conference/event, month and year of presentation, and any other relevant details)
+- Certifications (name of certificate, institution issuing the certificate, year issued)
+- Relevant professional affiliations (organization name, years of participation)
+- Publications, including personal blog posts (title of published work, month and year of publication)
+- Training and courses (name of training or course, organization providing the training, month and year completed)


### PR DESCRIPTION
Reworks edits from closed PR #115 .

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/hiring-process/)

Changes proposed in this pull request:
- Splits hiring process into one page on process and one on gov-style resume
- Removes content that is repeated in individual job postings 
- Edits content for clarity
