### PR TITLE
Shorten logo text on small screen sizes

### DIFF
--- a/assets/css/site.scss
+++ b/assets/css/site.scss
@@ -5,13 +5,8 @@ h2 {
   margin-top: 3em;
 }
 
-// only show on narrow screens
 .usa-nav {
   display: none;
-
-  &.is-visible {
-    display: flex;
-  }
 }
 
 // Sticky sidebar
@@ -20,6 +15,22 @@ h2 {
     .sidenav {
       position: sticky;
       top: 0;
+    }
+  }
+}
+
+// Shorten logo text on small screen sizes
+@media screen and (max-width: 369px) {
+  .usa-logo-text {
+    a {
+      display: none;
+    }
+  }
+
+  .usa-logo-text {
+    &::after {
+      content: "Join TTS";
+      color: #fff;
     }
   }
 }


### PR DESCRIPTION
Fixes issue(s) #134, #109.

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/fix-logo-bug/)

Changes proposed in this pull request:
- Change logo text to "Join TTS" from "Join the Technology Transformation Services" on small screen sizes.
-
-
![](http://g.recordit.co/8rIy2wj0aL.gif)
/cc @relevant-people
