### PR TITLE
include uswds js file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,3 +67,4 @@ styles:
 # Add GovDelivery
 scripts:
   - https://content.govdelivery.com/overlay/js/6387.js
+  - /assets/uswds/js/uswds.min.js


### PR DESCRIPTION
Fixes broken "how you know" link in the very top bar of the join site.

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/fix-how-you-know-link/)

Changes proposed in this pull request:
- include the uswds js file.

All credit to @hursey013 for identifying the fix!!!
