### PR TITLE
Visual refresh banner - Part II: The Empire Strikes Back

### DIFF
--- a/assets/css/site.scss
+++ b/assets/css/site.scss
@@ -27,7 +27,7 @@ a:active {
 
 // Set banner background color
 .usa-banner {
-  background-color: #d8f7ff; }
+  background-color: #FCFAFD; }
 
 // Set header background color
 .usa-header {


### PR DESCRIPTION
Re-creating the PR (Background context: #233 - JoinTTS has been removed from Federalist staging) 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/visual-refresh-banner/)

Changes proposed in this pull request:
- Make banner more neutral, less distracting that doesn't draw attention away from the main content. Previously light blue; now light grey

/cc @Dahianna 