### PR TITLE
Rename usages of `locations` to `location`.

### DIFF
--- a/pages/positions/login-application-engineer.md
+++ b/pages/positions/login-application-engineer.md
@@ -8,7 +8,7 @@ job_post_type: tts
 role_name: Application Engineer
 opens: 'tbd'
 closes: 'tbd'
-locations: 'Washington, DC; San Francisco, CA; Chicago, IL; New York, NY; Virtual (100% remote)'
+location: 'Washington, DC; San Francisco, CA; Chicago, IL; New York, NY; Virtual (100% remote)'
 gs_level: 15
 salary_min: '106,595'
 salary_max: '138,572'

--- a/pages/positions/login-devops-engineer.md
+++ b/pages/positions/login-devops-engineer.md
@@ -9,7 +9,7 @@ job_post_type: tts
 role_name: DevOps/Site Reliability Engineer
 opens: 'tbd'
 closes: 'tbd'
-locations: 'Washington, DC; San Francisco, CA; Chicago, IL; New York, NY; Virtual (100% remote)'
+location: 'Washington, DC; San Francisco, CA; Chicago, IL; New York, NY; Virtual (100% remote)'
 gs_level: 15
 salary_min: '106,595'
 salary_max: '138,572'

--- a/pages/positions/strategist.md
+++ b/pages/positions/strategist.md
@@ -8,7 +8,7 @@ job_post_type: tts
 role_name: Strategist
 opens: 'February 25, 2019, 8:00am EDT'
 closes: 'March 1, 2019, 8:00pm EDT'
-locations: 'Washington, DC; Chicago, IL; San Francisco, CA; New York, NY; Virtual (100% remote)'
+location: 'Washington, DC; Chicago, IL; San Francisco, CA; New York, NY; Virtual (100% remote)'
 gs_level: 15
 salary_min: '105,123'
 salary_max: '136,659'


### PR DESCRIPTION
All job postings should have `location:` defined in the front matter, not `locations:`. Most positions already use `location:` correctly — just found these three that (incorrectly) use `locations:`. 

/cc @amandaschonfeld @JennMoran 
