### PR TITLE
adding in a past positions page

### DIFF
--- a/pages/past-positions.md
+++ b/pages/past-positions.md
@@ -11,9 +11,7 @@ subnav:
     href: "#Application-process"
   - text: About TTS
     href: "#about-technology-transformation-services"
-
 ---
-
 
 This is a list of positions we've hired for in the past. We use this page as a resource for people and teams across government to use when writing position descriptions in their agencies. If you have questions or comments, please reach out to [joinTTS@gsa.gov](mailto:joinTTS@gsa.gov).
 

--- a/pages/past-positions.md
+++ b/pages/past-positions.md
@@ -1,0 +1,32 @@
+---
+title: Past Positions
+permalink: past-positions/
+
+subnav:
+  - text: Open positions
+    href: "#open-positions"
+  - text: Upcoming positions
+    href: "#upcoming-positions"
+  - text: Application process
+    href: "#Application-process"
+  - text: About TTS
+    href: "#about-technology-transformation-services"
+
+---
+
+
+This is a list of positions we've hired for in the past. We use this page as a resource for people and teams across government to use when writing position descriptions in their agencies. If you have questions or comments, please reach out to [joinTTS@gsa.gov](mailto:joinTTS@gsa.gov).
+
+Take a look at [our list of open and upcoming positions »]({{ site.baseurl }}/)
+
+{% assign sortedpages = site.pages | sort: 'title' %}
+
+### Closed Positions
+
+{% for pg in sortedpages %}
+  {% if pg.state == 'closed' %}
+    {% unless pg.path contains 'template'  %}
+    * [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }}) (Open now through {{ pg.closes | date: '%A, %B %e, %Y at %l:%M%P %Z' }})
+    {% endunless %}
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
Based off a conversation with the talent team, they'd like to be able to send people to a page that lists out past positions. These job descriptions are incredibly helpful in a number of contexts, including other agencies using them as examples of how to hire for design and development specialists.

AT the moment, this page will no be linked to from any other page. This will merely make the page that lists the past positions available at a URL. We can add in the link to this page in another PR.

CC @DebBaptiste @LeighFinkel  — can you give this a review?

Preview: 