### PR TITLE
changed salary verbiage in template

### DIFF
--- a/pages/positions/zz_template_position.md
+++ b/pages/positions/zz_template_position.md
@@ -48,7 +48,7 @@ title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
 **Salary Range:**
 The base salary range for this position is: GS-{{ page.gs_level }} Step 1 - ${{ page.salary_min }} to GS-{{ page.gs_level }} Step 10 ${{ page.salary_max }}
 
-The base salary range does not include any adjustment for locality. Your locality will be determined by where you live since most of our positions are remote. If the position isn't remote, then your locality will be determined by the location of the office where the position is based.
+The base salary range does not include any adjustment for locality. Your salary, including base and locality, will be determined upon selection, dependent on your actual duty location.
 
 You can find more information about this in the [compensation and benefits section on our site](https://join.tts.gsa.gov/compensation-and-benefits/).
 


### PR DESCRIPTION
changed to salary verbiage per Lynne's suggestion to "The base salary range does not include any adjustment for locality. Your salary, including base and locality, will be determined upon selection, dependent on your actual duty location"

