### PR TITLE
Update banner in site.scss

### DIFF
--- a/assets/css/site.scss
+++ b/assets/css/site.scss
@@ -27,7 +27,7 @@ a:active {
 
 // Set banner background color
 .usa-banner {
-  background-color: #d8f7ff; }
+  background-color: #F1F1F1; }
 
 // Set header background color
 .usa-header {


### PR DESCRIPTION
What: Set #d8f7ff blue to #f1f1f1 light gray

Why: Visually, make banner draws less attention away from other more important elements, i.e. nav, menu, etc

Comparison - Old blue (left) vs. new gray (right)

<img width="1340" alt="banners-comparison" src="https://user-images.githubusercontent.com/6327082/67422480-2e2c4c80-f598-11e9-9d97-11f2a040044d.png">


