### PR TITLE
Update compensation-and-benefits.md link

### DIFF
--- a/pages/compensation-and-benefits.md
+++ b/pages/compensation-and-benefits.md
@@ -84,4 +84,4 @@ about working at TTS, including:
 -   [Benefits](https://handbook.18f.gov/benefits/)
 -   [Leave](https://handbook.18f.gov/benefits/#leave)
 -   [Telework and virtual worker policy](https://handbook.18f.gov/telework/)
--   [Professional development and training processes](https://handbook.18f.gov/attending-conferences/)
+-   [Professional development and training processes](https://handbook.18f.gov/conferences-events-training/)


### PR DESCRIPTION
Looks like the page was renamed from https://handbook.18f.gov/attending-conferences/ to https://handbook.18f.gov/conferences-events-training/