### PR TITLE
Add 18F director info sessions

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -55,6 +55,11 @@ We hold periodic info sessions to offer potential candidates an opportunity to l
 {% if pg.state == 'upcoming' %}
 {% unless pg.path contains 'template'  %}
 * [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }})
+{% if pg.info_sessions %}
+{% for session in info_sessions %}
+    * {{ pg.title }} info session, <a href={{session.link}}>{{ session.date }}, at {{ session.time }}</a>
+{% endfor %}
+{% endif %}
 {% endunless %}
 {% endif %}
 {% endfor %}

--- a/pages/index.md
+++ b/pages/index.md
@@ -56,8 +56,8 @@ We hold periodic info sessions to offer potential candidates an opportunity to l
 {% unless pg.path contains 'template'  %}
 * [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }})
 {% if pg.info_sessions %}
-{% for session in info_sessions %}
-    * {{ pg.title }} info session, <a href={{session.link}}>{{ session.date }}, at {{ session.time }}</a>
+{% for session in pg.info_sessions %}
+    * {{ pg.title }} info session, [{{ session.date }}, at {{ session.time }}]({{ session.link }})
 {% endfor %}
 {% endif %}
 {% endunless %}

--- a/pages/positions/18F-executive-director.md
+++ b/pages/positions/18F-executive-director.md
@@ -3,6 +3,16 @@ title: 18F - Director
 permalink: /join/executive-director/
 state: upcoming
 job_post_type: tts
+info_sessions:
+  - link: https://www.eventbrite.com/e/tts-info-session-18f-director-tickets-160977821999
+    date: Wednesday, July 7
+    time: 6am PDT / 9am EDT
+  - link: https://www.eventbrite.com/e/tts-info-session-18f-director-tickets-160989813867
+    date: Monday, July 12
+    time: 9am PDT / 12pm EDT
+  - link: https://www.eventbrite.com/e/tts-info-session-18f-director-tickets-160990229109
+    date: Wednesday, July 14
+    time: 2pm PDT / 5pm EDT
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: 'Director'


### PR DESCRIPTION
This PR adds the ability to add info sessions to a job's markdown file. This allows us to display the info sessions inline for each position (and enables the future possibility of advertising the info sessions on each job's page). 

The frontmatter in `pages/positions.18f-executive-director.md` now looks like this:
```
---
title: 18F - Director
permalink: /join/executive-director/
state: upcoming
job_post_type: tts
info_sessions:
  - link: https://www.eventbrite.com/e/tts-info-session-18f-director-tickets-160977821999
    date: Wednesday, July 7
    time: 6am PDT / 9am EDT
  - link: https://www.eventbrite.com/e/tts-info-session-18f-director-tickets-160989813867
    date: Monday, July 12
    time: 9am PDT / 12pm EDT
  - link: https://www.eventbrite.com/e/tts-info-session-18f-director-tickets-160990229109
    date: Wednesday, July 14
    time: 2pm PDT / 5pm EDT

# INSTRUCTIONS UPCOMING: These fields are required for upcoming
[all the rest is the same as previously]
---
```

This renders like this:
<img width="639" alt="Screen Shot 2021-06-24 at 1 44 20 PM" src="https://user-images.githubusercontent.com/509309/123330334-bf349300-d4f2-11eb-8b89-97d9b16fcb87.png">
