### PR TITLE
Rename default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     interval: daily
     time: "09:00"
   open-pull-requests-limit: 10
-  target-branch: master
+  target-branch: main


### PR DESCRIPTION
https://github.com/18F/tts-tech-portfolio/issues/519

Rename default branch master -> main
