### PR TITLE
Add chapter director "landing page" and performance profiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,14 @@ jobs:
 
       - restore_cache:
           keys:
-            - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-v1-{{ arch }}-{{ .Branch }}
-            - gem-cache-v1
+            - gem-cache-v2-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - gem-cache-v2-{{ arch }}-{{ .Branch }}
+            - gem-cache-v2
       - run:
           name: Install dependencies
           command: bundle install --path vendor/bundle
       - save_cache:
-          key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: gem-cache-v2-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 

--- a/_config.yml
+++ b/_config.yml
@@ -61,6 +61,11 @@ defaults:
       type: pages
     values:
       layout: job
+  - scope:
+      path: pages/performance-profiles
+      type: pages
+    values:
+      layout: job
 
 styles:
   - /assets/css/site.css

--- a/_includes/upcoming_statement.html
+++ b/_includes/upcoming_statement.html
@@ -1,4 +1,4 @@
-If you would like to learn more or if you'd like to be notified when the application is open, please sign up <a href="https://join.tts.gsa.gov/newsletter/">join our mailing list</a>.
+If you would like to learn more or if you'd like to be notified when the application is open, please <a href="https://join.tts.gsa.gov/newsletter/">join our mailing list</a>.
 {% if page.job_post_type == 'usajobs' %}
 We will be accepting applications through the Public Notice on USAJOBS.
 {% endif %}

--- a/_includes/upcoming_statement.html
+++ b/_includes/upcoming_statement.html
@@ -1,1 +1,4 @@
 If you would like to learn more or if you'd like to be notified when the application is open, please sign up <a href="https://join.tts.gsa.gov/newsletter/">join our mailing list</a>.
+{% if page.job_post_type == 'usajobs' %}
+We will be accepting applications through the Public Notice on USAJOBS.
+{% endif %}

--- a/pages/index.md
+++ b/pages/index.md
@@ -29,12 +29,14 @@ upcoming positions. Take a look below, and [join our mailing list]({{ site.baseu
 
 {% for pg in sortedpages %}
 {% if pg.state == 'open' %}
-{% unless pg.path contains 'template'  %}
+{% unless pg.path contains 'template' %}
+{% unless pg.path contains 'performance-profiles' %}
 * [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }}) (Open now through {{ pg.closes | date: '%A, %B %e, %Y at %l:%M%P %Z' }})
 {% endunless %}
 {% elsif pg.state == 'usajobs' %}
 {% unless pg.path contains 'template'  %}
 * [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }}) (Open now through {{ pg.closes | date: '%A, %B %e, %Y at %l:%M%P %Z' }})
+{% endunless %}
 {% endunless %}
 {% endif %}
 {% endfor %}
@@ -53,13 +55,15 @@ We hold periodic info sessions to offer potential candidates an opportunity to l
 
 {% for pg in sortedpages %}
 {% if pg.state == 'upcoming' %}
-{% unless pg.path contains 'template'  %}
+{% unless pg.path contains 'template' %}
+{% unless pg.path contains 'performance-profiles' %}
 * [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }})
 {% if pg.info_sessions %}
 {% for session in pg.info_sessions %}
     * {{ pg.title }} info session, [{{ session.date }}, at {{ session.time }}]({{ session.link }})
 {% endfor %}
 {% endif %}
+{% endunless %}
 {% endunless %}
 {% endif %}
 {% endfor %}

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -1,0 +1,107 @@
+---
+title: 18F
+permalink: /join/performance-profiles/18f-account-management-director/
+state: upcoming
+job_post_type: usajobs
+related_position:
+  - name: 18F Chapter director
+  - link: /join/bucket-18f-chapter-directors
+related_performance_profiles:
+  - name: '18F Product Director'
+    link: /join/performance-profiles/18f-product-director/
+  - name: '18F Design Director'
+    link: /join/performance-profiles/18f-design-director/
+info_sessions:
+  - text: Info session 1
+    link: eventbrite
+  - text: Info session 2
+    link: eventbrite
+
+# INSTRUCTIONS UPCOMING: These fields are required for upcoming
+role_name: Chapter director
+gs_level: '15'
+org: 18F
+---
+{% if page.state == 'upcoming' %}
+{{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.related_position.name }} posting]({{ page.related_position.link }}).
+{% endif %}
+
+{% if page.state != 'upcoming' %}
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
+{% endif %}
+
+# Attend an information session
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
+
+{% for session in page.info_sessions %}
+- [{{session.text}}]({{session.link}})
+{% endfor %}
+
+## Role summary
+
+18F delivers agile IT procurement, software design and development, and consulting services to agency partners across government. We use an iterative, user-centered approach to help our government partners modernize technology and build capacity for innovation. 18F chapter directors foster inclusion, belonging, and growth within their teams. In this role, you’ll help shape how 18F creates meaningful change for our partners, stakeholders, and the American public.  
+The 18F Account Management Director leads the 18F chapter focused on creating and maintaining partnerships with government agencies and programs. You’ll support employee development, lead hiring for 18F’s Account Management chapter, set a vision for the chapter, and represent the Account Management chapter as a member of 18F leadership. 
+
+You’ll support a team of Account Managers, who are:
+- Experienced leaders, playing a critical strategic role on project teams. It is not a junior role, though it is the least hands-on role within any project team. 
+- Essential to the business development (BD), agreements, and pre-flight phases of a project
+- Key holders of partner relationships
+- Keepers of institutional knowledge
+- An important player in our project delivery and quality assurance processes 
+
+## Key objectives
+
+### Objective #1: Provide coaching, mentorship, and professional development opportunities; support employee wellbeing
+-  Assign work to chapter members based on priorities, selective consideration of the difficulty and requirements of assignments, and the capabilities of employees. 
+-  Ensure continued technical excellence in your chapter. 
+-  Communicate regularly with your team, as a group and in 1:1s, to provide mentorship and guidance, and help remove obstacles to their success. 
+-  Steward the Account Management chapter’s professional development by identifying appropriate training, developmental assignments, and/or details. Incorporate equity and inclusion into training, speaking events, and experiential learning opportunities. Tailor approaches to individuals’ needs. 
+-  Work with individuals to identify and develop their strengths, helping team members pursue opportunities that enhance their talents. 
+-  Constructively address situations, issues, and behaviors. Initiate difficult conversations and clearly communicate corrective actions. 
+-  Recognize and flag stress and fatigue in your chapter. Work with individuals to determine support that might improve their wellbeing. Determine mechanisms to provide that support. 
+-  Collaborate with other members of 18F leadership to identify and support strategic training opportunities. 
+-  Ensure employees receive reasonable accommodations and that team events are accessible. 
+-  Support the onboarding of new Account Management chapter staff. 
+-  Conduct and document employee performance plans, mid-year, and end-of-year performance evaluations. 
+
+### Objective #2: Provide strategic leadership
+-  Serve on the 18F senior management team, which is responsible for operations of the business, employee management, and providing strategic leadership to staff. 
+-  Work to develop and maintain program components in all areas of operations and delivery, including marketing, sales, performance management, organizational compliance, project success, and partner relationships.
+-  Use data-driven decision making to make strategic decisions on behalf of the organization.
+-  Solicit input from staff members and communicates decisions and plans to staff in a transparent manner.
+-  Provide advice to other members of the Senior Management Team, and advise the Executive Director on key operational and delivery decisions.
+-  Facilitate partnerships with stakeholders, establishing effective internal and external lines of communications, seeking and advising senior level officials on best practices and coordinating meetings, working groups designed to improve TTS practices.
+-  Collect feedback to discuss successes and challenges, and share patterns and key feedback with the rest of 18F leadership
+-  Represent the chapter in the 18F Senior Management Team (SMT) and communicate information back to the chapter. Promote transparency in how decisions are made. Regularly include others in planning and decision-making. 
+-  Create a work environment that fosters trust, respect, and collaboration, since the best work comes from including diverse skill sets and backgrounds. Uphold TTS values of inclusion, integrity, and impact. 
+-  Identify power dynamics in situations; respond thoughtfully and open space for less powerful voices. 
+-  Promote collective success; plan and ensure there is time for collaborative decision-making; acknowledge how others’ contributions led to achievements; and create shared ownership of success, risks, and accountability.
+-  Craft strategic, data-driven hiring plans for the Product chapter that align with TTS’s hiring strategy and trends in partner needs. Include sourcing strategies and interview practices to ensure a diverse candidate pool and inclusive hiring process. Our goal is for our team to reflect the diversity of the American public. 
+-  Ensure Equal Employment Opportunity (EEO) regulations are followed throughout recruitment, hiring, and selection processes. 
+-  Set strategy for knowledge management such that key information is carried forward, to make the chapter resilient to turnover. 
+
+### Objective #3: Support 18F project teams and build stronger organization-wide practices
+-  Help 18F teams align on and adhere to shared processes, maintain high standards, and resolve conflicts. Connect teams to resources, amplify team successes, and help teams to pivot or adapt as needed. 
+-  Help 18F project teams understand what success looks like. Work with project teams to regularly demonstrate our expertise and impact. 
+-  As part of 18F leadership, provide oversight of partner engagements and help members of the Account Management chapter contribute meaningfully to partner and user success.
+-  Collaborate with SMT and staffing leads to ensure projects are staffed with Account Management chapter expertise to best meet the needs of partners as well as to support skills growth of team members.
+-  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives. 
+-  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press. 
+
+## {{ page.related_performance_profiles | size | plus: 1 }} {{ page.org }} teams are hiring for this role
+
+The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
+{% for profile in page.related_performance_profiles %}
+  - [{{profile.name}}]({{profile.permalink}})
+{% endfor %}
+
+## Preparing to apply
+
+This Join TTS site has information about [the application process](https://join.tts.gsa.gov/hiring-process/) and [how to prepare a government-style resume](https://join.tts.gsa.gov/resume/).
+
+### Attend an information session
+
+{% for session in page.info_sessions %}
+- [{{session.text}}]({{session.link}})
+{% endfor %}

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -1,5 +1,5 @@
 ---
-title: 18F
+title: 18F - Account management director
 permalink: /join/performance-profiles/18f-account-management-director/
 state: upcoming
 job_post_type: usajobs

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -25,9 +25,9 @@ org: 18F
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]{{site.baseurl}}({{ page.parent_position_link }})
 {% endif %}
 
+{% if page.info_sessions %}
 ## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
-{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
@@ -95,8 +95,8 @@ The links below provide descriptions specific to each {{ page.org }} team. When 
 
 This Join TTS site has information about [the application process](https://join.tts.gsa.gov/hiring-process/) and [how to prepare a government-style resume](https://join.tts.gsa.gov/resume/).
 
-### Attend an information session
 {% if page.info_sessions %}
+### Attend an information session
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -3,9 +3,8 @@ title: 18F - Account management director
 permalink: /join/performance-profiles/18f-account-management-director/
 state: upcoming
 job_post_type: usajobs
-related_position:
-  - name: 18F Chapter director
-  - link: /join/bucket-18f-chapter-directors
+parent_position_name: 18F Chapter director
+parent_position_link: /join/bucket-18f-chapter-directors
 related_performance_profiles:
   - name: '18F Product Director'
     link: /join/performance-profiles/18f-product-director/
@@ -24,11 +23,11 @@ org: 18F
 ---
 {% if page.state == 'upcoming' %}
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.related_position.name }} posting]({{ page.related_position.link }}).
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{ page.parent_position_link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.parent_position_link }})
 {% endif %}
 
 ## Attend an information session

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -88,7 +88,7 @@ You’ll support a team of Account Managers, who are:
 
 The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
 {% for profile in page.related_performance_profiles %}
-  - [{{profile.name}}]{{site.baseurl}}({{profile.link}})
+  - [{{profile.name}}]({{site.baseurl}}{{profile.link}})
 {% endfor %}
 
 ## Preparing to apply

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -10,11 +10,6 @@ related_performance_profiles:
     link: /join/performance-profiles/18f-product-director/
   - name: '18F Design Director'
     link: /join/performance-profiles/18f-design-director/
-info_sessions:
-  - text: Info session 1
-    link: eventbrite
-  - text: Info session 2
-    link: eventbrite
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter director
@@ -32,10 +27,11 @@ org: 18F
 
 ## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
-
+{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% endif %}
 
 ## Role summary
 
@@ -100,7 +96,8 @@ The links below provide descriptions specific to each {{ page.org }} team. When 
 This Join TTS site has information about [the application process](https://join.tts.gsa.gov/hiring-process/) and [how to prepare a government-style resume](https://join.tts.gsa.gov/resume/).
 
 ### Attend an information session
-
+{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% endif %}

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -23,11 +23,11 @@ org: 18F
 ---
 {% if page.state == 'upcoming' %}
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{ page.parent_position_link }}).
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]{{site.baseurl}}({{ page.parent_position_link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.parent_position_link }})
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]{{site.baseurl}}({{ page.parent_position_link }})
 {% endif %}
 
 ## Attend an information session
@@ -88,11 +88,11 @@ You’ll support a team of Account Managers, who are:
 -  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives. 
 -  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press. 
 
-## {{ page.related_performance_profiles | size | plus: 1 }} {{ page.org }} teams are hiring for this role
+## Three {{ page.org }} teams are hiring for this role
 
 The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
 {% for profile in page.related_performance_profiles %}
-  - [{{profile.name}}]({{profile.permalink}})
+  - [{{profile.name}}]{{site.baseurl}}({{profile.link}})
 {% endfor %}
 
 ## Preparing to apply

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -31,7 +31,7 @@ org: 18F
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
 {% endif %}
 
-# Attend an information session
+## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
 
 {% for session in page.info_sessions %}

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -25,12 +25,15 @@ org: 18F
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]{{site.baseurl}}({{ page.parent_position_link }})
 {% endif %}
 
-{% if page.info_sessions %}
 ## Attend an information session
-Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. 
+{% if page.info_sessions %}
+Register for a session using the Eventbrite links below.
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% else %}
+These sessions are not yet scheduled. We'll post dates and registration links here soon.
 {% endif %}
 
 ## Role summary

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -18,7 +18,7 @@ org: 18F
 ---
 {% if page.state == 'upcoming' %}
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]{{site.baseurl}}({{ page.parent_position_link }}).
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{site.baseurl}}{{ page.parent_position_link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}

--- a/pages/performance-profiles/18f-design-director.md
+++ b/pages/performance-profiles/18f-design-director.md
@@ -25,10 +25,10 @@ org: 18F
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{site.baseurl}}{{ page.parent_position_link}})
 {% endif %}
 
+{% if page.info_sessions %}
 ## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
 
-{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
@@ -87,8 +87,8 @@ The links below provide descriptions specific to each {{ page.org }} team. When 
 
 This Join TTS site has information about [the application process](https://join.tts.gsa.gov/hiring-process/) and [how to prepare a government-style resume](https://join.tts.gsa.gov/resume/).
 
-### Attend an information session
 {% if page.info_sessions %}
+### Attend an information session
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}

--- a/pages/performance-profiles/18f-design-director.md
+++ b/pages/performance-profiles/18f-design-director.md
@@ -10,11 +10,6 @@ related_performance_profiles:
     link: /join/performance-profiles/18f-product-director/
   - name: '18F Account Management Director'
     link: /join/performance-profiles/18f-account-management-director/
-info_sessions:
-  - text: Info session 1
-    link: eventbrite
-  - text: Info session 2
-    link: eventbrite
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter director
@@ -33,9 +28,11 @@ org: 18F
 ## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
 
+{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% endif %}
 
 ## Role summary
 
@@ -91,7 +88,8 @@ The links below provide descriptions specific to each {{ page.org }} team. When 
 This Join TTS site has information about [the application process](https://join.tts.gsa.gov/hiring-process/) and [how to prepare a government-style resume](https://join.tts.gsa.gov/resume/).
 
 ### Attend an information session
-
+{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% endif %}

--- a/pages/performance-profiles/18f-design-director.md
+++ b/pages/performance-profiles/18f-design-director.md
@@ -23,11 +23,11 @@ org: 18F
 ---
 {% if page.state == 'upcoming' %}
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{ page.parent_position_link }}).
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{site.baseurl}}{{ page.parent_position_link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.parent_position_link}})
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{site.baseurl}}{{ page.parent_position_link}})
 {% endif %}
 
 ## Attend an information session
@@ -79,12 +79,11 @@ The 18F Design Director sets the vision for design work on cross-functional team
 -  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives. 
 -  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press. 
 
-
-## {{ page.related_performance_profiles | size | plus: 1 }} {{ page.org }} teams are hiring for this role
+## Three {{ page.org }} teams are hiring for this role
 
 The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
 {% for profile in page.related_performance_profiles %}
-  - [{{profile.name}}]({{profile.permalink}})
+  - [{{profile.name}}]{{site.baseurl}}({{profile.link}})
 {% endfor %}
 
 ## Preparing to apply

--- a/pages/performance-profiles/18f-design-director.md
+++ b/pages/performance-profiles/18f-design-director.md
@@ -1,5 +1,5 @@
 ---
-title: 18F
+title: 18F - Design director
 permalink: /join/performance-profiles/18f-design-director/
 state: upcoming
 job_post_type: usajobs

--- a/pages/performance-profiles/18f-design-director.md
+++ b/pages/performance-profiles/18f-design-director.md
@@ -1,0 +1,99 @@
+---
+title: 18F
+permalink: /join/performance-profiles/18f-design-director/
+state: upcoming
+job_post_type: usajobs
+related_position:
+  - name: 18F Chapter director
+  - link: /join/bucket-18f-chapter-directors
+related_performance_profiles:
+  - name: '18F Product Director'
+    link: /join/performance-profiles/18f-product-director/
+  - name: '18F Account Management Director'
+    link: /join/performance-profiles/18f-account-management-director/
+info_sessions:
+  - text: Info session 1
+    link: eventbrite
+  - text: Info session 2
+    link: eventbrite
+
+# INSTRUCTIONS UPCOMING: These fields are required for upcoming
+role_name: Chapter director
+gs_level: '15'
+org: 18F
+---
+{% if page.state == 'upcoming' %}
+{{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.related_position.name }} posting]({{ page.related_position.link }}).
+{% endif %}
+
+{% if page.state != 'upcoming' %}
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
+{% endif %}
+
+# Attend an information session
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
+
+{% for session in page.info_sessions %}
+- [{{session.text}}]({{session.link}})
+{% endfor %}
+
+## Role summary
+
+18F delivers agile IT procurement, software design and development, and consulting services to agency partners across government. We use an iterative, user-centered approach to help our government partners modernize technology and build capacity for innovation. 18F chapter directors foster inclusion, belonging, and growth within their teams. In this role, you’ll help shape how 18F creates meaningful change for our partners, stakeholders, and the American public. 
+The 18F Design Director sets the vision for design work on cross-functional teams to deliver digital products & services. You’ll lead the 18F Design chapter in all aspects of design at 18F, including product design, experience design, user research, content strategy, service design, and organizational design. You’ll support employee development, lead hiring for 18F’s Design chapter, set a vision for the chapter, and represent the Design chapter as a member of 18F leadership. 
+
+## Key objectives
+
+### Objective #1: Provide coaching, mentorship, and professional development opportunities; support employee wellbeing
+- Ensure continued technical excellence in your chapter. 
+-  Collaborate with other members of 18F leadership to identify and support strategic training opportunities. 
+-  Communicate regularly with your team, as a group and in 1:1s, to provide mentorship and guidance, and help remove obstacles to their success. 
+-  Steward the Design chapter’s professional development by identifying appropriate training, developmental assignments, and/or details. Incorporate equity and inclusion into training, speaking events, and experiential learning opportunities. Tailor approaches to individuals’ needs. 
+-  Work with individuals to identify and develop their strengths, helping team members pursue opportunities that enhance their talents. 
+-  Constructively address situations, issues, and behaviors. Initiate difficult conversations and clearly communicate corrective actions. 
+-  Recognize and flag stress and fatigue in your chapter. Work with individuals to determine support that might improve their wellbeing. Determine mechanisms to provide that support. 
+-  Ensure employees receive reasonable accommodations and that team events are accessible. 
+-  Support the onboarding of new Design chapter staff.
+-  Conduct and document employee performance plans, mid-year, and end-of-year performance evaluations. 
+
+### Objective #2: Provide strategic leadership
+- Set the vision for the 18F Design chapter, aligning with 18F / TTS vision, goals, and values. 
+-  Lead strategic 18F initiatives. 
+-  Coordinate with other members of the 18F leadership team to develop guidance and organizational communication. 
+-  Collect feedback to discuss successes and challenges, and share patterns and key feedback with the rest of 18F leadership. 
+-  Represent the chapter in the 18F Senior Management Team (SMT) and communicate information back to the chapter. Promote transparency in how decisions are made. Regularly include others in planning and decision-making. 
+-  Create a work environment that fosters trust, respect, and collaboration, since the best work comes from including diverse skill sets and backgrounds. Uphold TTS values of inclusion, integrity, and impact. 
+-  Identify power dynamics in situations; respond thoughtfully and open space for less powerful voices. 
+-  Promote collective success; plan and ensure there is time for collaborative decision-making; acknowledge how others’ contributions led to achievements; and create shared ownership of success, risks, and accountability.
+-  Identify 18F and Design chapter processes in need of improvement and oversee improvement activities. 
+-  Research, develop, and encourage best practices in the sub-disciplines of design and user research, and create space for experimentation and iteration. 
+-  Craft strategic, data-driven hiring plans for the Design chapter that align with TTS’s hiring strategy and trends in partner needs. Include sourcing strategies and interview practices to ensure a diverse candidate pool and inclusive hiring process. Our goal is for our team to reflect the diversity of the American public. 
+-  Ensure Equal Employment Opportunity (EEO) regulations are followed throughout recruitment, hiring, and selection processes. 
+-  Set strategy for knowledge management such that key information is carried forward, to make the chapter resilient to turnover.
+
+### Objective #3: Support 18F project teams and build stronger organization-wide practices
+-  Help 18F teams align on and adhere to shared processes, maintain high standards, and resolve conflicts. Connect teams to resources, amplify team successes, and help teams to pivot or adapt as needed. 
+-  Help 18F project teams understand what success looks like. Work with project teams to regularly demonstrate our expertise and impact. 
+-  As part of 18F leadership, provide oversight of partner engagements and help members of the Design chapter contribute meaningfully to partner and user success.
+-  Collaborate with SMT and staffing leads to ensure projects are staffed with Design chapter expertise to best meet the needs of partners as well as to support skills growth of team members.
+-  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives. 
+-  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press. 
+
+
+## {{ page.related_performance_profiles | size | plus: 1 }} {{ page.org }} teams are hiring for this role
+
+The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
+{% for profile in page.related_performance_profiles %}
+  - [{{profile.name}}]({{profile.permalink}})
+{% endfor %}
+
+## Preparing to apply
+
+This Join TTS site has information about [the application process](https://join.tts.gsa.gov/hiring-process/) and [how to prepare a government-style resume](https://join.tts.gsa.gov/resume/).
+
+### Attend an information session
+
+{% for session in page.info_sessions %}
+- [{{session.text}}]({{session.link}})
+{% endfor %}

--- a/pages/performance-profiles/18f-design-director.md
+++ b/pages/performance-profiles/18f-design-director.md
@@ -31,7 +31,7 @@ org: 18F
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
 {% endif %}
 
-# Attend an information session
+## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
 
 {% for session in page.info_sessions %}

--- a/pages/performance-profiles/18f-design-director.md
+++ b/pages/performance-profiles/18f-design-director.md
@@ -80,7 +80,7 @@ The 18F Design Director sets the vision for design work on cross-functional team
 
 The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
 {% for profile in page.related_performance_profiles %}
-  - [{{profile.name}}]{{site.baseurl}}({{profile.link}})
+  - [{{profile.name}}]({{site.baseurl}}{{profile.link}})
 {% endfor %}
 
 ## Preparing to apply

--- a/pages/performance-profiles/18f-design-director.md
+++ b/pages/performance-profiles/18f-design-director.md
@@ -3,9 +3,8 @@ title: 18F - Design director
 permalink: /join/performance-profiles/18f-design-director/
 state: upcoming
 job_post_type: usajobs
-related_position:
-  - name: 18F Chapter director
-  - link: /join/bucket-18f-chapter-directors
+parent_position_name: 18F Chapter director
+parent_position_link: /join/bucket-18f-chapter-directors
 related_performance_profiles:
   - name: '18F Product Director'
     link: /join/performance-profiles/18f-product-director/
@@ -24,11 +23,11 @@ org: 18F
 ---
 {% if page.state == 'upcoming' %}
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.related_position.name }} posting]({{ page.related_position.link }}).
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{ page.parent_position_link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.parent_position_link}})
 {% endif %}
 
 ## Attend an information session

--- a/pages/performance-profiles/18f-design-director.md
+++ b/pages/performance-profiles/18f-design-director.md
@@ -25,13 +25,15 @@ org: 18F
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{site.baseurl}}{{ page.parent_position_link}})
 {% endif %}
 
-{% if page.info_sessions %}
 ## Attend an information session
-Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
-
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. 
+{% if page.info_sessions %}
+Register for a session using the Eventbrite links below.
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% else %}
+These sessions are not yet scheduled. We'll post dates and registration links here soon.
 {% endif %}
 
 ## Role summary

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -3,9 +3,8 @@ title: 18F Product director
 permalink: /join/performance-profiles/18f-product-director/
 state: upcoming
 job_post_type: usajobs
-related_position:
-  - name: 18F Chapter director
-  - link: /join/bucket-18f-chapter-directors
+parent_position_name: 18F Chapter director
+parent_position_link: /join/bucket-18f-chapter-directors
 related_performance_profiles:
   - name: '18F Design Director'
     link: /join/performance-profiles/18f-design-director/
@@ -24,11 +23,11 @@ org: 18F
 ---
 {% if page.state == 'upcoming' %}
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.related_position.name }} posting]({{ page.related_position.link }}).
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{ page.parent_position_link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.parent_position_link }})
 {% endif %}
 
 ## Attend an information session

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -1,0 +1,111 @@
+---
+title: 18F Product director 
+permalink: /join/performance-profiles/18f-product-director/
+state: upcoming
+job_post_type: usajobs
+related_position:
+  - name: 18F Chapter director
+  - link: /join/bucket-18f-chapter-directors
+related_performance_profiles:
+  - name: '18F Design Director'
+    link: /join/wtf-goes-here-i-hate-jekyll
+  - name: '18F Account Management Director'
+    link: /join/wtf-goes-here-i-hate-jekyll
+info_sessions:
+  - text: Info session 1
+    link: eventbrite
+  - text: Info session 2
+    link: eventbrite
+
+# INSTRUCTIONS UPCOMING: These fields are required for upcoming
+role_name: Chapter director
+# opens: MONTH DAY, YEAR, TIME EDT
+# closes: MONTH DAY, YEAR, TIME EDT
+# location: ENTER LOCATIONS - 'Washington, DC; San Francisco, CA; Chicago, IL; New York, NY; Virtual (100% Remote)'
+gs_level: '15'
+# salary_min: 'ENTER SALARY MIN' (XXX,XXX)
+# salary_max: 'ENTER SALARY MAX' (XXX,XXX)
+org: 18F
+# contact_name: 'TTS Talent Team'
+# contact_email: 'jointts@gsa.gov'
+---
+{% if page.state == 'upcoming' %}
+{{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles.
+  {% if page.opens == 'tbd' %} The target date for when these positions will be officially open to application has not yet been determined. If you'd like to be
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter).
+  {% endif %}
+  
+  Applications will be open for submission on {{ page.opens | date: '%A, %B %e, %Y' }}. Check out [Join TTS Hiring Process]({{site.baseurl}}/hiring-process/) to
+  learn more about the application process. 
+{% endif %}
+
+{% if page.state != 'upcoming' %}
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other 18F chapter director positions.]({{ related_position.link }})
+{% endif %}
+
+
+## Attend an information session
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
+
+{% for session in page.info_sessions %}
+- [{{session.text}}]({{session.link}})
+{% endfor %}
+
+## Role summary
+
+18F delivers agile IT procurement, software design and development, and consulting services to agency partners across government. We use an iterative, user-centered approach to help our government partners modernize technology and build capacity for innovation. 18F chapter directors foster inclusion, belonging, and growth within their teams. In this role, you’ll help shape how 18F creates meaningful change for our partners, stakeholders, and the American public. 
+The 18F Product Director leads the 18F chapter focused on driving products from concept to delivery. 18F product managers are strategic thinkers who are comfortable defining a compelling vision and designing a measurable strategy to achieve that vision. You’ll support employee development, lead hiring for 18F’s Product chapter, set a vision for the chapter, and represent the Product chapter as a member of 18F leadership. 
+
+## Key objectives
+
+### Objective #1: Provide coaching, mentorship, and professional development opportunities; support employee wellbeing
+-  Ensure continued technical excellence in your chapter. 
+-  Communicate regularly with your team, as a group and in 1:1s, to provide mentorship and guidance, and help remove obstacles to their success. 
+-  Steward the Product chapter’s professional development by identifying appropriate training, developmental assignments, and/or details. Incorporate equity and inclusion into training, speaking events, and experiential learning opportunities. Tailor approaches to individuals’ needs. 
+-  Work with individuals to identify and develop their strengths, helping team members pursue opportunities that enhance their talents. 
+-  Constructively address situations, issues, and behaviors. Initiate difficult conversations and clearly communicate corrective actions. 
+-  Recognize and flag stress and fatigue in your chapter. Work with individuals to determine support that might improve their wellbeing. Determine mechanisms to provide that support. 
+-  Collaborate with other members of 18F leadership to identify and support strategic training opportunities. 
+-  Ensure employees receive reasonable accommodations and that team events are accessible. 
+-  Support the onboarding of new Product chapter staff. 
+-  Conduct and document employee performance plans, mid-year, and end-of-year performance evaluations. 
+
+###  Objective #2: Provide strategic leadership
+-  Set the vision for the 18F Product chapter, aligning with 18F / TTS vision, goals, and values. 
+-  Lead strategic 18F initiatives. 
+-  Coordinate with other members of the 18F leadership team to develop guidance and organizational communication. 
+-  Collect feedback to discuss successes and challenges, and share patterns and key feedback with the rest of 18F leadership. 
+-  Represent the chapter in the 18F Senior Management Team (SMT) and communicate information back to the chapter. Promote transparency in how decisions are made. Regularly include others in planning and decision-making. 
+-  Create a work environment that fosters trust, respect, and collaboration, since the best work comes from including diverse skill sets and backgrounds. Uphold TTS values of inclusion, integrity, and impact. 
+-  Identify power dynamics in situations; respond thoughtfully and open space for less powerful voices. 
+-  Promote collective success; plan and ensure there is time for collaborative decision-making; acknowledge how others’ contributions led to achievements; and create shared ownership of success, risks, and accountability.
+-  Identify 18F and Product chapter processes in need of improvement and oversee improvement activities. 
+-  Research, develop, and encourage best practices in the field of product management, and create space for experimentation and iteration. 
+-  Craft strategic, data-driven hiring plans for the Product chapter that align with TTS’s hiring strategy and trends in partner needs. Include sourcing strategies and interview practices to ensure a diverse candidate pool and inclusive hiring process. Our goal is for our team to reflect the diversity of the American public. 
+-  Ensure Equal Employment Opportunity (EEO) regulations are followed throughout recruitment, hiring, and selection processes. 
+-  Set strategy for knowledge management such that key information is carried forward, to make the chapter resilient to turnover. 
+
+###  Objective #3: Support 18F project teams and build stronger organization-wide practices
+-  Help 18F teams align on and adhere to shared processes, maintain high standards, and resolve conflicts. Connect teams to resources, amplify team successes, and help teams to pivot or adapt as needed. 
+-  Help 18F project teams understand what success looks like. Work with project teams to regularly demonstrate our expertise and impact. 
+-  As part of 18F leadership, provide oversight of partner engagements and help members of the Product chapter contribute meaningfully to partner and user success.
+-  Collaborate with SMT and staffing leads to ensure projects are staffed with Product chapter expertise to best meet the needs of partners as well as to support skills growth of team members.
+-  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives. 
+-  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press. 
+
+## {{ page.related_performance_profiles | size | plus: 1 }} {{ page.org }} teams are hiring for this role
+
+The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
+{% for profile in page.related_performance_profiles %}
+  - [{{profile.name}}]({{profile.permalink}})
+{% endfor %}
+
+## Preparing to apply
+
+This Join TTS site has information about [the application process](https://join.tts.gsa.gov/hiring-process/) and [how to prepare a government-style resume](https://join.tts.gsa.gov/resume/).
+
+### Attend an information session
+
+{% for session in page.info_sessions %}
+- [{{session.text}}]({{session.link}})
+{% endfor %}

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -25,13 +25,15 @@ org: 18F
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]{{site.baseurl}}({{ page.parent_position_link }})
 {% endif %}
 
-{% if page.info_sessions %}
 ## Attend an information session
-Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
-
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. 
+{% if page.info_sessions %}
+Register for a session using the Eventbrite links below.
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% else %}
+These sessions are not yet scheduled. We'll post dates and registration links here soon.
 {% endif %}
 
 ## Role summary

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -25,10 +25,10 @@ org: 18F
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]{{site.baseurl}}({{ page.parent_position_link }})
 {% endif %}
 
+{% if page.info_sessions %}
 ## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
 
-{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
@@ -87,8 +87,8 @@ The links below provide descriptions specific to each {{ page.org }} team. When 
 
 This Join TTS site has information about [the application process](https://join.tts.gsa.gov/hiring-process/) and [how to prepare a government-style resume](https://join.tts.gsa.gov/resume/).
 
-### Attend an information session
 {% if page.info_sessions %}
+### Attend an information session
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -10,11 +10,6 @@ related_performance_profiles:
     link: /join/performance-profiles/18f-design-director/
   - name: '18F Account Management Director'
     link: /join/performance-profiles/18f-account-management-director/
-info_sessions:
-  - text: Info session 1
-    link: eventbrite
-  - text: Info session 2
-    link: eventbrite
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter director
@@ -33,9 +28,11 @@ org: 18F
 ## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
 
+{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% endif %}
 
 ## Role summary
 
@@ -91,7 +88,8 @@ The links below provide descriptions specific to each {{ page.org }} team. When 
 This Join TTS site has information about [the application process](https://join.tts.gsa.gov/hiring-process/) and [how to prepare a government-style resume](https://join.tts.gsa.gov/resume/).
 
 ### Attend an information session
-
+{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% endif %}

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -19,28 +19,16 @@ info_sessions:
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter director
-# opens: MONTH DAY, YEAR, TIME EDT
-# closes: MONTH DAY, YEAR, TIME EDT
-# location: ENTER LOCATIONS - 'Washington, DC; San Francisco, CA; Chicago, IL; New York, NY; Virtual (100% Remote)'
 gs_level: '15'
-# salary_min: 'ENTER SALARY MIN' (XXX,XXX)
-# salary_max: 'ENTER SALARY MAX' (XXX,XXX)
 org: 18F
-# contact_name: 'TTS Talent Team'
-# contact_email: 'jointts@gsa.gov'
 ---
 {% if page.state == 'upcoming' %}
-{{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles.
-  {% if page.opens == 'tbd' %} The target date for when these positions will be officially open to application has not yet been determined. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter).
-  {% endif %}
-  
-  Applications will be open for submission on {{ page.opens | date: '%A, %B %e, %Y' }}. Check out [Join TTS Hiring Process]({{site.baseurl}}/hiring-process/) to
-  learn more about the application process. 
+{{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.related_position.name }} posting]({{ page.related_position.link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other 18F chapter director positions.]({{ related_position.link }})
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
 {% endif %}
 
 

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -18,7 +18,7 @@ org: 18F
 ---
 {% if page.state == 'upcoming' %}
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]{{site.baseurl}}({{ page.parent_position_link }}).
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{site.baseurl}}{{ page.parent_position_link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -8,9 +8,9 @@ related_position:
   - link: /join/bucket-18f-chapter-directors
 related_performance_profiles:
   - name: '18F Design Director'
-    link: /join/wtf-goes-here-i-hate-jekyll
+    link: /join/performance-profiles/18f-design-director/
   - name: '18F Account Management Director'
-    link: /join/wtf-goes-here-i-hate-jekyll
+    link: /join/performance-profiles/18f-account-management-director/
 info_sessions:
   - text: Info session 1
     link: eventbrite
@@ -30,7 +30,6 @@ org: 18F
 {% if page.state != 'upcoming' %}
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
 {% endif %}
-
 
 ## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -80,7 +80,7 @@ The 18F Product Director leads the 18F chapter focused on driving products from 
 
 The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
 {% for profile in page.related_performance_profiles %}
-  - [{{profile.name}}]{{site.baseurl}}({{profile.link}})
+  - [{{profile.name}}]({{site.baseurl}}{{profile.link}})
 {% endfor %}
 
 ## Preparing to apply

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -23,11 +23,11 @@ org: 18F
 ---
 {% if page.state == 'upcoming' %}
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{ page.parent_position_link }}).
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]{{site.baseurl}}({{ page.parent_position_link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.parent_position_link }})
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]{{site.baseurl}}({{ page.parent_position_link }})
 {% endif %}
 
 ## Attend an information session
@@ -79,11 +79,11 @@ The 18F Product Director leads the 18F chapter focused on driving products from 
 -  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives. 
 -  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press. 
 
-## {{ page.related_performance_profiles | size | plus: 1 }} {{ page.org }} teams are hiring for this role
+## Three {{ page.org }} teams are hiring for this role
 
 The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
 {% for profile in page.related_performance_profiles %}
-  - [{{profile.name}}]({{profile.permalink}})
+  - [{{profile.name}}]{{site.baseurl}}({{profile.link}})
 {% endfor %}
 
 ## Preparing to apply

--- a/pages/performance-profiles/zz-template-performance-profile.md
+++ b/pages/performance-profiles/zz-template-performance-profile.md
@@ -3,9 +3,8 @@ title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
 # permalink: /join/performance-profiles/ENTER ROLE TITLE HERE/
 # state: ENTER STATE HERE (open, closed, upcoming)
 # job_post_type: ENTER TYPE HERE (tts or usajobs)
-# related_position:
-# - name: ENTER NAME OF OVERARCHING POSITION HERE
-#   link: /join/ENTER POSITION LINK HERE
+# parent_position_name: ENTER NAME OF OVERARCHING POSITION HERE
+# parent_position_link: /join/ENTER POSITION LINK HERE
 # related_performance_profiles:
 #  - name: NAME OF PERFORMANCE PROFILE
 #    link: /join/ENTER PERFORMANCE PROFILE PAGENAME HERE
@@ -24,11 +23,11 @@ title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
 ---
 {% if page.state == 'upcoming' %}
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.related_position.name }} posting]({{ page.related_position.link }}).
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{ page.parent_position_link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.parent_position_link }})
 {% endif %}
 
 ## Attend an information session

--- a/pages/performance-profiles/zz-template-performance-profile.md
+++ b/pages/performance-profiles/zz-template-performance-profile.md
@@ -23,11 +23,11 @@ title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
 ---
 {% if page.state == 'upcoming' %}
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
-  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{ page.parent_position_link }}).
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.parent_position_name }} posting]({{site.baseurl}}{{ page.parent_position_link }}).
 {% endif %}
 
 {% if page.state != 'upcoming' %}
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.parent_position_link }})
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{site.baseurl}}{{ page.parent_position_link }})
 {% endif %}
 
 ## Attend an information session
@@ -57,7 +57,7 @@ ENTER ROLE SUMMARY HERE
 
 The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
 {% for profile in page.related_performance_profiles %}
-  - [{{profile.name}}]({{profile.permalink}})
+  - [{{profile.name}}]{{site.baseurl}}({{profile.link}})
 {% endfor %}
 
 ## Preparing to apply

--- a/pages/performance-profiles/zz-template-performance-profile.md
+++ b/pages/performance-profiles/zz-template-performance-profile.md
@@ -31,11 +31,15 @@ title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
 {% endif %}
 
 ## Attend an information session
-Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
-
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. 
+{% if page.info_sessions %}
+Register for a session using the Eventbrite links below.
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% else %}
+These sessions are not yet scheduled. We'll post dates and registration links here soon.
+{% endif %}
 
 ## Role summary
 

--- a/pages/performance-profiles/zz-template-performance-profile.md
+++ b/pages/performance-profiles/zz-template-performance-profile.md
@@ -31,7 +31,7 @@ title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
 {% endif %}
 
-# Attend an information session
+## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
 
 {% for session in page.info_sessions %}

--- a/pages/performance-profiles/zz-template-performance-profile.md
+++ b/pages/performance-profiles/zz-template-performance-profile.md
@@ -1,0 +1,72 @@
+---
+title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE 
+# permalink: /join/performance-profiles/ENTER ROLE TITLE HERE/
+# state: ENTER STATE HERE (open, closed, upcoming)
+# job_post_type: ENTER TYPE HERE (tts or usajobs)
+# related_position:
+# - name: ENTER NAME OF OVERARCHING POSITION HERE
+#   link: /join/ENTER POSITION LINK HERE
+# related_performance_profiles:
+#  - name: NAME OF PERFORMANCE PROFILE
+#    link: /join/ENTER PERFORMANCE PROFILE PAGENAME HERE
+#  - name: (repeat as necessary)
+#    link: (repeat as necessary)
+# info_sessions:
+#  - text: TEXT FOR INFO SESSION LINK
+#    link: EVENTBRITE LINK
+#  - text: (repeat as necessary)
+#    link: (repeat as necessary)
+
+# INSTRUCTIONS UPCOMING: These fields are required for upcoming
+# role_name: ENTER THE NAME OF THE ROLE HERE (Without Org)
+# gs_level: ENTER GS LEVEL (13, 14, 15, etc)
+# org: 'ENTER ORG NAME HERE' (18F, Centers of Excellence, etc.)
+---
+{% if page.state == 'upcoming' %}
+{{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles. If you'd like to be
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter). More details are available on [the main {{ page.related_position.name }} posting]({{ page.related_position.link }}).
+{% endif %}
+
+{% if page.state != 'upcoming' %}
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a summary of the {{ page.title }} role. [View descriptions of other {{ page.org }} {{ page.role_name }} positions.]({{ page.related_position.link }})
+{% endif %}
+
+# Attend an information session
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
+
+{% for session in page.info_sessions %}
+- [{{session.text}}]({{session.link}})
+{% endfor %}
+
+## Role summary
+
+ENTER ROLE SUMMARY HERE
+
+## Key objectives
+
+### Objective #1: ENTER OBJECTIVE NAME
+- X
+- X
+- X
+
+### Objective #2: ENTER OBJECTIVE NAME
+- X
+- X
+- X
+
+## {{ page.related_performance_profiles | size | plus: 1 }} {{ page.org }} teams are hiring for this role
+
+The links below provide descriptions specific to each {{ page.org }} team. When the role is posted and open for application on USAJobs, you can indicate which team(s) you’re interested in.
+{% for profile in page.related_performance_profiles %}
+  - [{{profile.name}}]({{profile.permalink}})
+{% endfor %}
+
+## Preparing to apply
+
+This Join TTS site has information about [the application process](https://join.tts.gsa.gov/hiring-process/) and [how to prepare a government-style resume](https://join.tts.gsa.gov/resume/).
+
+### Attend an information session
+
+{% for session in page.info_sessions %}
+- [{{session.text}}]({{session.link}})
+{% endfor %}

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -1,5 +1,5 @@
 ---
-title: 18F Chapter Director 
+title: 18F Chapter Directors 
 permalink: /join/bucket-18f-chapter-directors/
 state: upcoming
 job_post_type: usajobs
@@ -56,7 +56,7 @@ contact_email: 'jointts@gsa.gov'
 {% endif %}
 
 {% if page.state != 'upcoming' %}
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role..** This page contains a high-level summary of the role and links to more specific descriptions for each {{ page.title }}. **When the position becomes live for applications, you will have the opportunity to select which role(s) you’re interested in applying for.**
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a high-level summary of the role and links to more specific descriptions for each {{ page.title }}. **When the position becomes live for applications, you will have the opportunity to select which role(s) you’re interested in applying for.**
 {% endif %}
 
 ## Attend an information session
@@ -71,16 +71,16 @@ Attend an information session to learn more about these roles, working at {{ pag
 These opportunities are located in the General Services Administration (GSA), Federal Acquisition Service (FAS), Technology Transformation Services (TTS), Office of 18F. 18F helps other government agencies build, buy, and share technology products. 
 18F envisions a country whose government consistently offers digital services that instill pride and trust, meet user needs, are secure, and are delivered quickly and at reasonable cost.
 
-18F develops partnerships with agencies to help them deliver exceptional digital experiences that address their strategic initiatives. Through our work together, we also aim to strengthen government technology practices in ways that last beyond our formal partnerships. We effect change by practicing user-centered development, testing to validate hypotheses, shipping often, and deploying products in the open.
+18F develops partnerships with agencies to help them deliver exceptional digital experiences that address their strategic initiatives. Through our work together, we aim to strengthen government technology practices in ways that last beyond our formal partnerships. We effect change by practicing user-centered development, testing to validate hypotheses, shipping often, and deploying products in the open.
 
-The 18F Chapter Directors XXX. This is a great opportunity for you if you genuinely care about people and creating great outcomes for agencies in support of delivering value to our partners, stakeholders, and the American public. 
+The 18F Chapter Directors set the vision in their discipline to support improving government services for all who need them, and to help the civil servants who deliver those services.
 
 Chapter Directors:
-- Focus on delivering customer or partner success. 
-- Create and cultivate strong partnerships with TTS government partners. 
-- Own significant parts of the engagement or business development / sales cycle.
-- Drive adoption of TTS services.
-- Oversee and advise on project delivery. 
+- Support growth of their teams’ ability to deliver partner success
+- Help deliver partner success 
+- Create and cultivate strong partnerships with TTS government partners
+- Own significant parts of the engagement or business development / sales cycle
+- Oversee and advise on project delivery
 
 ## {{ page.org }} teams hiring for this role
 

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -17,8 +17,8 @@ opens: tbd
 closes: tbd
 location: 'Washington, DC; San Francisco, CA; Chicago, IL; New York, NY; Virtual (100% Remote)'
 gs_level: 15
-salary_min: 128,078
-salary_max: 172,500
+salary_min: '128,078'
+salary_max: '172,500'
 org: 18F
 contact_name: 'TTS Talent Team'
 contact_email: 'jointts@gsa.gov'

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -10,15 +10,6 @@ related_performance_profiles:
     link: /join/performance-profiles/18f-product-director/
   - name: '18F Account Management Director'
     link: /join/performance-profiles/18f-account-management-director/
-info_sessions:
-  - text: Info session 1
-    link: eventbrite
-    date: xx
-    time: xx
-  - text: Info session 2
-    link: eventbrite
-    date: xx
-    time: xx
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter Director
@@ -61,11 +52,11 @@ contact_email: 'jointts@gsa.gov'
 
 ## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
-
+{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
-
+{% endif %}
 ## Opportunity overview
 
 These opportunities are located in the General Services Administration (GSA), Federal Acquisition Service (FAS), Technology Transformation Services (TTS), Office of 18F. 18F helps other government agencies build, buy, and share technology products. 
@@ -73,7 +64,7 @@ These opportunities are located in the General Services Administration (GSA), Fe
 
 18F develops partnerships with agencies to help them deliver exceptional digital experiences that address their strategic initiatives. Through our work together, we aim to strengthen government technology practices in ways that last beyond our formal partnerships. We effect change by practicing user-centered development, testing to validate hypotheses, shipping often, and deploying products in the open.
 
-The 18F Chapter Directors set the vision in their discipline to support improving government services for all who need them, and to help the civil servants who deliver those services.
+18F Chapter Directors set the vision in their discipline to support improving government services for all who need them, and to help the civil servants who deliver those services.
 
 Chapter Directors:
 - Support growth of their teams’ ability to deliver partner success

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -5,11 +5,11 @@ state: upcoming
 job_post_type: usajobs
 related_performance_profiles:
   - name: '18F Design Director'
-    link: /join/wtf-goes-here-i-hate-jekyll
+    link: /join/performance-profiles/18f-design-director/
   - name: '18F Product Director'
     link: /join/performance-profiles/18f-product-director/
   - name: '18F Account Management Director'
-    link: /join/wtf-goes-here-i-hate-jekyll
+    link: /join/performance-profiles/18f-account-management-director/
 info_sessions:
   - text: Info session 1
     link: eventbrite

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -50,9 +50,9 @@ contact_email: 'jointts@gsa.gov'
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a high-level summary of the role and links to more specific descriptions for each {{ page.title }}. **When the position becomes live for applications, you will have the opportunity to select which role(s) you’re interested in applying for.**
 {% endif %}
 
+{% if page.info_sessions %}
 ## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
-{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -87,7 +87,7 @@ Chapter Directors:
 **There are several {{ page.org }} teams hiring for this role.** The links below provide more specific descriptions of these opportunities. Candidates will submit one application and will indicate which position(s) they want to be considered for. 
 
 {% for profile in page.related_performance_profiles %}
-  - [{{profile.name}}]({{profile.link}})
+  - [{{profile.name}}]{{site.baseurl}}({{profile.link}})
 {% endfor %}
 
 Once applications are reviewed, hiring teams will identify candidates that they are interested in interviewing. We will then follow up with candidates to discuss their interest in the role(s). Candidates may interview for roles with multiple teams.

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -87,7 +87,7 @@ Chapter Directors:
 **There are several {{ page.org }} teams hiring for this role.** The links below provide more specific descriptions of these opportunities. Candidates will submit one application and will indicate which position(s) they want to be considered for. 
 
 {% for profile in page.related_performance_profiles %}
-  - [{{profile.name}}]{{site.baseurl}}({{profile.link}})
+  - [{{profile.name}}]({{site.baseurl}}{{profile.link}})
 {% endfor %}
 
 Once applications are reviewed, hiring teams will identify candidates that they are interested in interviewing. We will then follow up with candidates to discuss their interest in the role(s). Candidates may interview for roles with multiple teams.

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -13,8 +13,12 @@ related_performance_profiles:
 info_sessions:
   - text: Info session 1
     link: eventbrite
+    date: xx
+    time: xx
   - text: Info session 2
     link: eventbrite
+    date: xx
+    time: xx
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter Director

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -13,12 +13,12 @@ related_performance_profiles:
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter Director
-opens: TBD
-closes: TBD
+opens: tbd
+closes: tbd
 location: 'Washington, DC; San Francisco, CA; Chicago, IL; New York, NY; Virtual (100% Remote)'
 gs_level: 15
-salary_min: XXX,XXX
-salary_max: XXX,XXX
+salary_min: 128,078
+salary_max: 172,500
 org: 18F
 contact_name: 'TTS Talent Team'
 contact_email: 'jointts@gsa.gov'
@@ -40,9 +40,10 @@ contact_email: 'jointts@gsa.gov'
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles.
   {% if page.opens == 'tbd' %} The target date for when these positions will be officially open to application has not yet been determined. If you'd like to be
   notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter).
+  {% else %} 
+  Applications will be open for submission on {{ page.opens | date: '%A, %B %e, %Y' }}. 
   {% endif %}
-  
-  Applications will be open for submission on {{ page.opens | date: '%A, %B %e, %Y' }}. Check out [Join TTS Hiring Process]({{site.baseurl}}/hiring-process/) to
+  Check out [Join TTS Hiring Process]({{site.baseurl}}/hiring-process/) to
   learn more about the application process. 
 {% endif %}
 
@@ -50,13 +51,17 @@ contact_email: 'jointts@gsa.gov'
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role.** This page contains a high-level summary of the role and links to more specific descriptions for each {{ page.title }}. **When the position becomes live for applications, you will have the opportunity to select which role(s) you’re interested in applying for.**
 {% endif %}
 
-{% if page.info_sessions %}
 ## Attend an information session
-Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. 
+{% if page.info_sessions %}
+Register for a session using the Eventbrite links below.
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% else %}
+These sessions are not yet scheduled. We'll post dates and registration links here soon.
 {% endif %}
+
 ## Opportunity overview
 
 These opportunities are located in the General Services Administration (GSA), Federal Acquisition Service (FAS), Technology Transformation Services (TTS), Office of 18F. 18F helps other government agencies build, buy, and share technology products. 
@@ -75,7 +80,7 @@ Chapter Directors:
 
 ## {{ page.org }} teams hiring for this role
 
-**There are several {{ page.org }} teams hiring for this role.** The links below provide more specific descriptions of these opportunities. Candidates will submit one application and will indicate which position(s) they want to be considered for. 
+**There are several {{ page.org }} teams hiring for this role.** The links below provide more specific descriptions of these opportunities. 
 
 {% for profile in page.related_performance_profiles %}
   - [{{profile.name}}]({{site.baseurl}}{{profile.link}})
@@ -142,9 +147,6 @@ For each job on your resume, provide:
 - The exact dates you held each job (from month/year to month/year or “present”)
 - Number of hours per week you worked (if part time)
 
-## How to apply
-We will be accepting applications through the Public Notice on USAJOBS.
-
 {% if page.job_announcement_number %}
 **Job announcement number:**
 {{ page.job_announcement_number }}
@@ -155,7 +157,12 @@ We will be accepting applications through the Public Notice on USAJOBS.
 {{ page.series }} - {{ page.gs_level }}
 {% endif %}
 
-{% if page.opens %}
+{% if page.opens == 'tbd' %}
+**Opening and closing period for this job application**
+
+The target date for when these positions will be officially open to application has not yet been determined. If you'd like to be
+notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter).
+{% else %}
 **Opening and closing period for this job application**
 {{ page.opens }} to {{ page.closes }}
 {% endif %}

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -5,11 +5,11 @@ state: upcoming
 job_post_type: usajobs
 related_performance_profiles:
   - name: '18F Design Director'
-    permalink: /join/wtf-goes-here-i-hate-jekyll
+    link: /join/wtf-goes-here-i-hate-jekyll
   - name: '18F Product Director'
-    permalink: /join/wtf-goes-here-i-hate-jekyll
+    link: /join/performance-profiles/18f-product-director/
   - name: '18F Account Management Director'
-    permalink: /join/wtf-goes-here-i-hate-jekyll
+    link: /join/wtf-goes-here-i-hate-jekyll
 info_sessions:
   - text: Info session 1
     link: eventbrite
@@ -41,7 +41,19 @@ contact_email: 'jointts@gsa.gov'
 # promotion_potential: 'ENTER THE GS LEVEL' (13, 14, 15, etc.)
 # supervisory_status: 'YES' or 'NO'
 ---
+{% if page.state == 'upcoming' %}
+{{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles.
+  {% if page.opens == 'tbd' %} The target date for when these positions will be officially open to application has not yet been determined. If you'd like to be
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter).
+  {% endif %}
+  
+  Applications will be open for submission on {{ page.opens | date: '%A, %B %e, %Y' }}. Check out [Join TTS Hiring Process]({{site.baseurl}}/hiring-process/) to
+  learn more about the application process. 
+{% endif %}
+
+{% if page.state != 'upcoming' %}
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role..** This page contains a high-level summary of the role and links to more specific descriptions for each {{ page.title }}. **When the position becomes live for applications, you will have the opportunity to select which role(s) you’re interested in applying for.**
+{% endif %}
 
 ## Attend an information session
 Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
@@ -71,7 +83,7 @@ Chapter Directors:
 **There are several {{ page.org }} teams hiring for this role.** The links below provide more specific descriptions of these opportunities. Candidates will submit one application and will indicate which position(s) they want to be considered for. 
 
 {% for profile in page.related_performance_profiles %}
-  - [{{profile.name}}]({{profile.permalink}})
+  - [{{profile.name}}]({{profile.link}})
 {% endfor %}
 
 Once applications are reviewed, hiring teams will identify candidates that they are interested in interviewing. We will then follow up with candidates to discuss their interest in the role(s). Candidates may interview for roles with multiple teams.
@@ -137,3 +149,18 @@ For each job on your resume, provide:
 
 ## How to apply
 We will be accepting applications through the Public Notice on USAJOBS.
+
+{% if page.job_announcement_number %}
+**Job announcement number:**
+{{ page.job_announcement_number }}
+{% endif %}
+
+{% if page.series %}
+**Series and grade:**
+{{ page.series }} - {{ page.gs_level }}
+{% endif %}
+
+{% if page.opens %}
+**Opening and closing period for this job application**
+{{ page.opens }} to {{ page.closes }}
+{% endif %}

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -1,0 +1,139 @@
+---
+title: 18F Chapter Director 
+permalink: /join/bucket-18f-chapter-directors/
+state: upcoming
+job_post_type: usajobs
+related_performance_profiles:
+  - name: '18F Design Director'
+    permalink: /join/wtf-goes-here-i-hate-jekyll
+  - name: '18F Product Director'
+    permalink: /join/wtf-goes-here-i-hate-jekyll
+  - name: '18F Account Management Director'
+    permalink: /join/wtf-goes-here-i-hate-jekyll
+info_sessions:
+  - text: Info session 1
+    link: eventbrite
+  - text: Info session 2
+    link: eventbrite
+
+# INSTRUCTIONS UPCOMING: These fields are required for upcoming
+role_name: Chapter Director
+opens: TBD
+closes: TBD
+location: 'Washington, DC; San Francisco, CA; Chicago, IL; New York, NY; Virtual (100% Remote)'
+gs_level: 15
+salary_min: XXX,XXX
+salary_max: XXX,XXX
+org: 18F
+contact_name: 'TTS Talent Team'
+contact_email: 'jointts@gsa.gov'
+
+# INSTRUCTIONS OPEN: These fields are required for open
+
+# job_announcement_number: 'ENTER JOB ANNOUNCEMENT NUMBER'
+# pd_job_title: 'Innovation Specialist' (ENTER TITLE IF DIFFERENT)
+# num_vacancies: 'ENTER NUMBER OF VACANCIES'
+# series: '0301' ENTER SERIES IF DIFFERENT
+# apply_url: APPLICATION URL
+# ohrm_contact_email: 'ENTER OHRM CONTACT EMAIL'
+# ohrm_contact_name: 'ENTER OHRM CONTACT NAME'
+# bargaining_unit: 'Non Bargaining Unit'
+# promotion_potential: 'ENTER THE GS LEVEL' (13, 14, 15, etc.)
+# supervisory_status: 'YES' or 'NO'
+---
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role..** This page contains a high-level summary of the role and links to more specific descriptions for each {{ page.title }}. **When the position becomes live for applications, you will have the opportunity to select which role(s) you’re interested in applying for.**
+
+## Attend an information session
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. Register for a session using the Eventbrite links below.
+
+{% for session in page.info_sessions %}
+- [{{session.text}}]({{session.link}})
+{% endfor %}
+
+## Opportunity overview
+
+These opportunities are located in the General Services Administration (GSA), Federal Acquisition Service (FAS), Technology Transformation Services (TTS), Office of 18F. 18F helps other government agencies build, buy, and share technology products. 
+18F envisions a country whose government consistently offers digital services that instill pride and trust, meet user needs, are secure, and are delivered quickly and at reasonable cost.
+
+18F develops partnerships with agencies to help them deliver exceptional digital experiences that address their strategic initiatives. Through our work together, we also aim to strengthen government technology practices in ways that last beyond our formal partnerships. We effect change by practicing user-centered development, testing to validate hypotheses, shipping often, and deploying products in the open.
+
+The 18F Chapter Directors XXX. This is a great opportunity for you if you genuinely care about people and creating great outcomes for agencies in support of delivering value to our partners, stakeholders, and the American public. 
+
+Chapter Directors:
+- Focus on delivering customer or partner success. 
+- Create and cultivate strong partnerships with TTS government partners. 
+- Own significant parts of the engagement or business development / sales cycle.
+- Drive adoption of TTS services.
+- Oversee and advise on project delivery. 
+
+## {{ page.org }} teams hiring for this role
+
+**There are several {{ page.org }} teams hiring for this role.** The links below provide more specific descriptions of these opportunities. Candidates will submit one application and will indicate which position(s) they want to be considered for. 
+
+{% for profile in page.related_performance_profiles %}
+  - [{{profile.name}}]({{profile.permalink}})
+{% endfor %}
+
+Once applications are reviewed, hiring teams will identify candidates that they are interested in interviewing. We will then follow up with candidates to discuss their interest in the role(s). Candidates may interview for roles with multiple teams.
+
+## Basic information
+
+**Location:**
+{{ page.location }}
+
+**Salary Range:**
+The salary range for this position is: GS-{{ page.gs_level }} Step 1 - ${{ page.salary_min }} to GS-{{ page.gs_level }} Step 10 ${{ page.salary_max }}
+
+Your salary, including base and locality, will be determined upon selection, dependent on your actual duty location.
+
+You can find more information about this in the [compensation and benefits section on our site](https://join.tts.gsa.gov/compensation-and-benefits/).
+
+For specific details on locality pay, please visit [OPM's Salaries & Wages page](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/) or for a
+salary calculator [OPM's 2021 General Schedule (GS) Salary Calculator](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2021/general-schedule-gs-salary-calculator/).
+
+Please note the maximum salary available for the GS pay system is **$172,500** 
+
+Note: You may not be eligible for the maximum salary as it is locality dependent. Please refer to the maximum pay for your locality.
+
+**Who May Apply:**
+All United States citizens and nationals (residents of American Samoa and Swains Islands)
+
+**Travel requirement:**
+Occasional travel may be required up to 10%-20% per year
+
+**Security clearance:**
+Public trust. Background investigation required.
+
+**Work schedule:**
+Full time.
+
+**Appointment type:**
+Permanent hire. This is not a term limited opportunity. Applicants who are selected for this opportunity will have career conditional status in the federal government for their first three years of employment and transition to career after three years. This means you will be a permanent federal employee with no expiration date.
+
+**Employee benefits:**
+[Learn more about the benefits we offer.](https://join.tts.gsa.gov/compensation-and-benefits/)
+  - Health insurance (choose from a wide range of plans)
+  - Life insurance coverage with several options
+  - Sick leave and vacation time, including 10 paid holidays per year
+  - Thrift Savings Plan (similar to a 401(k) plan)
+  - Flexible work schedules and telework
+  - Transit and child care subsidies
+  - Training and development
+  - Flexible spending accounts
+  - Long-term care insurance
+  - Training and development
+  - Direct Deposit of salary check to financial organization required.
+
+## Qualifications
+To qualify for this role, you must have one year of specialized experience equivalent to the GS-14 in the federal service. Specialized experience for this role will be listed here as soon as it is available.
+
+Provide as much detail as possible on your resume so that we can evaluate your previous experience. Follow our [guidance on creating a federal style resume.](https://join.tts.gsa.gov/resume/)
+
+Qualification determinations can’t be made when resumes don’t include the required information. Failure to provide required information may result in disqualification.
+
+For each job on your resume, provide:
+- The exact dates you held each job (from month/year to month/year or “present”)
+- Number of hours per week you worked (if part time)
+
+## How to apply
+We will be accepting applications through the Public Notice on USAJOBS.

--- a/pages/positions/zz-template-bucket-position.md
+++ b/pages/positions/zz-template-bucket-position.md
@@ -5,9 +5,9 @@ title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
 # job_post_type: ENTER TYPE HERE (tts or usajobs)
 # related_performance_profiles:
 #  - name: NAME OF PERFORMANCE PROFILE
-#    permalink: /join/ENTER PERFORMANCE PROFILE PAGENAME HERE
+#    link: /join/ENTER PERFORMANCE PROFILE PAGENAME HERE
 #  - name: (repeat as necessary)
-#    permalink: (repeat as necessary)
+#    link: (repeat as necessary)
 # info_sessions:
 #  - text: TEXT FOR INFO SESSION LINK
 #    link: EVENTBRITE LINK
@@ -39,7 +39,19 @@ title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
 # promotion_potential: 'ENTER THE GS LEVEL' (13, 14, 15, etc.)
 # supervisory_status: 'YES' or 'NO'
 ---
-{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. *Several units within {{ page.org }} are hiring for this role.* This page contains a high-level summary of the role and links to more specific descriptions for each {{ page.title }}. *When the position becomes live for applications, you will have the opportunity to select which role(s) you’re interested in applying for.*
+{% if page.state == 'upcoming' %}
+{{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles.
+  {% if page.opens == 'tbd' %} The target date for when these positions will be officially open to application has not yet been determined. If you'd like to be
+  notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter).
+  {% endif %}
+  
+  Applications will be open for submission on {{ page.opens | date: '%A, %B %e, %Y' }}. Check out [Join TTS Hiring Process]({{site.baseurl}}/hiring-process/) to
+  learn more about the application process. 
+{% endif %}
+
+{% if page.state != 'upcoming' %}
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role..** This page contains a high-level summary of the role and links to more specific descriptions for each {{ page.title }}. **When the position becomes live for applications, you will have the opportunity to select which role(s) you’re interested in applying for.**
+{% endif %}
 
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})

--- a/pages/positions/zz-template-bucket-position.md
+++ b/pages/positions/zz-template-bucket-position.md
@@ -56,10 +56,11 @@ title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
 {% if page.state != 'upcoming' %}
 {{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. **There are several {{ page.org }} teams hiring for this role..** This page contains a high-level summary of the role and links to more specific descriptions for each {{ page.title }}. **When the position becomes live for applications, you will have the opportunity to select which role(s) you’re interested in applying for.**
 {% endif %}
-
+{% if page.info_sessions %}
 {% for session in page.info_sessions %}
 - [{{session.text}}]({{session.link}})
 {% endfor %}
+{% endif %}
 
 ## Opportunity overview
 

--- a/pages/positions/zz-template-bucket-position.md
+++ b/pages/positions/zz-template-bucket-position.md
@@ -1,0 +1,122 @@
+---
+title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
+# permalink: /join/ENTER ROLE TITLE HERE/
+# state: ENTER STATE HERE (open, closed, upcoming)
+# job_post_type: ENTER TYPE HERE (tts or usajobs)
+# related_performance_profiles:
+#  - name: NAME OF PERFORMANCE PROFILE
+#    permalink: /join/ENTER PERFORMANCE PROFILE PAGENAME HERE
+#  - name: (repeat as necessary)
+#    permalink: (repeat as necessary)
+# info_sessions:
+#  - text: TEXT FOR INFO SESSION LINK
+#    link: EVENTBRITE LINK
+#  - text: (repeat as necessary)
+#    link: (repeat as necessary)
+
+# INSTRUCTIONS UPCOMING: These fields are required for upcoming
+# role_name: ENTER THE NAME OF THE ROLE HERE (Without Org)
+# opens: MONTH DAY, YEAR, TIME EDT
+# closes: MONTH DAY, YEAR, TIME EDT
+# location: ENTER LOCATIONS - 'Washington, DC; San Francisco, CA; Chicago, IL; New York, NY; Virtual (100% Remote)'
+# gs_level: ENTER GS LEVEL (13, 14, 15, etc)
+# salary_min: 'ENTER SALARY MIN' (XXX,XXX)
+# salary_max: 'ENTER SALARY MAX' (XXX,XXX)
+# org: 'ENTER ORG NAME HERE' (18F, Centers of Excellence, etc.)
+# contact_name: 'TTS Talent Team'
+# contact_email: 'jointts@gsa.gov'
+
+# INSTRUCTIONS OPEN: These fields are required for open
+
+# job_announcement_number: 'ENTER JOB ANNOUNCEMENT NUMBER'
+# pd_job_title: 'Innovation Specialist' (ENTER TITLE IF DIFFERENT)
+# num_vacancies: 'ENTER NUMBER OF VACANCIES'
+# series: '0301' ENTER SERIES IF DIFFERENT
+# apply_url: APPLICATION URL
+# ohrm_contact_email: 'ENTER OHRM CONTACT EMAIL'
+# ohrm_contact_name: 'ENTER OHRM CONTACT NAME'
+# bargaining_unit: 'Non Bargaining Unit'
+# promotion_potential: 'ENTER THE GS LEVEL' (13, 14, 15, etc.)
+# supervisory_status: 'YES' or 'NO'
+---
+{{ page.org }} is hiring for the role of GS-{{ page.gs_level }} {{ page.role_name }}. *Several units within {{ page.org }} are hiring for this role.* This page contains a high-level summary of the role and links to more specific descriptions for each {{ page.title }}. *When the position becomes live for applications, you will have the opportunity to select which role(s) you’re interested in applying for.*
+
+{% for session in page.info_sessions %}
+- [{{session.text}}]({{session.link}})
+{% endfor %}
+
+## Opportunity overview
+
+ENTER OPPORTUNITY INFORMATION HERE.
+
+## {{ page.org }} teams hiring for this role
+
+**There are several {{ page.org }} teams hiring for this role.** The links below provide more specific descriptions of these opportunities. Candidates will submit one application and will indicate which position(s) they want to be considered for. 
+
+{% for profile in page.related_performance_profiles %}
+  - [{{profile.name}}]({{profile.permalink}})
+{% endfor %}
+
+Once applications are reviewed, hiring teams will identify candidates that they are interested in interviewing. We will then follow up with candidates to discuss their interest in the role(s). Candidates may interview for roles with multiple teams.
+
+## Basic information
+
+**Location:**
+{{ page.location }}
+
+**Salary Range:**
+The salary range for this position is: GS-{{ page.gs_level }} Step 1 - ${{ page.salary_min }} to GS-{{ page.gs_level }} Step 10 ${{ page.salary_max }}
+
+Your salary, including base and locality, will be determined upon selection, dependent on your actual duty location.
+
+You can find more information about this in the [compensation and benefits section on our site](https://join.tts.gsa.gov/compensation-and-benefits/).
+
+For specific details on locality pay, please visit [OPM's Salaries & Wages page](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/) or for a
+salary calculator [OPM's 2021 General Schedule (GS) Salary Calculator](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2021/general-schedule-gs-salary-calculator/).
+
+Please note the maximum salary available for the GS pay system is **$172,500** 
+
+Note: You may not be eligible for the maximum salary as it is locality dependent. Please refer to the maximum pay for your locality.
+
+**Who May Apply:**
+All United States citizens and nationals (residents of American Samoa and Swains Islands)
+
+**Travel requirement:**
+Occasional travel may be required up to 10%-20% per year
+
+**Security clearance:**
+Public trust. Background investigation required.
+
+**Work schedule:**
+Full time.
+
+**Appointment type:**
+Permanent hire. This is not a term limited opportunity. Applicants who are selected for this opportunity will have career conditional status in the federal government for their first three years of employment and transition to career after three years. This means you will be a permanent federal employee with no expiration date.
+
+**Employee benefits:**
+[Learn more about the benefits we offer.](https://join.tts.gsa.gov/compensation-and-benefits/)
+  - Health insurance (choose from a wide range of plans)
+  - Life insurance coverage with several options
+  - Sick leave and vacation time, including 10 paid holidays per year
+  - Thrift Savings Plan (similar to a 401(k) plan)
+  - Flexible work schedules and telework
+  - Transit and child care subsidies
+  - Training and development
+  - Flexible spending accounts
+  - Long-term care insurance
+  - Training and development
+  - Direct Deposit of salary check to financial organization required.
+
+## Qualifications
+To qualify for this role, you must have one year of specialized experience equivalent to the GS-14 in the federal service. Specialized experience for this role will be listed here as soon as it is available.
+
+Provide as much detail as possible on your resume so that we can evaluate your previous experience. Follow our [guidance on creating a federal style resume.](https://join.tts.gsa.gov/resume/)
+
+Qualification determinations can’t be made when resumes don’t include the required information. Failure to provide required information may result in disqualification.
+
+For each job on your resume, provide:
+- The exact dates you held each job (from month/year to month/year or “present”)
+- Number of hours per week you worked (if part time)
+
+## How to apply
+We will be accepting applications through the Public Notice on USAJOBS.

--- a/pages/positions/zz-template-bucket-position.md
+++ b/pages/positions/zz-template-bucket-position.md
@@ -11,8 +11,12 @@ title: ENTER OFFICE HERE - ENTER ROLE TITLE HERE
 # info_sessions:
 #  - text: TEXT FOR INFO SESSION LINK
 #    link: EVENTBRITE LINK
+#    date: ENTER DATE
+#    time: ENTER TIME
 #  - text: (repeat as necessary)
 #    link: (repeat as necessary)
+#    date: (repeat as necessary)
+#    time: (repeat as necessary)
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 # role_name: ENTER THE NAME OF THE ROLE HERE (Without Org)


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-217d62ed-a40b-4e63-ab27-952ee578ef00.app.cloud.gov/preview/18f/join.tts.gsa.gov/hjb/add-director-posting/)

This adds a chapter director "landing page" and three performance profiles.

While this is workable as-is, it's also still pretty manual and I'd like to refine it to be a bit more automatic. It should work just fine for right now, though!
