### PR TITLE
add info sessions to chpater directors posts

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -44,15 +44,23 @@ upcoming positions. Take a look below, and [join our mailing list]({{ site.baseu
 
 **We are hiring** and will be sharing upcoming jobs and open positions as they are available.
 
-#### Learn more about our open roles
+#### Learn more about our upcoming and open roles
 
 We hold periodic info sessions to offer potential candidates an opportunity to learn more about working at TTS, available positions, and our application process. You can register for a session using the EventBrite links below.
+##### General Hiring info session
 
-* General Hiring info session, [Thursday, September 23 at 12:30 pm EDT/9:30 am PDT](https://www.eventbrite.com/e/tts-talent-info-session-tickets-169179268747)
-* Centers of Excellence Director info session, [Tuesday, September 14th at 12:00 pm EDT/9:00 am PDT](https://www.eventbrite.com/e/tts-info-session-centers-of-excellence-tickets-168755222413)
-* Centers of Excellence Director info session, [Monday, September 20th at 5:00 pm EDT/2:00 pm PDT](https://www.eventbrite.com/e/tts-info-session-centers-of-excellence-tickets-168762668685)
-* Centers of Excellence Director info session, [Thursday, September 23rd at 9:00 am EDT/6:00 am PDT](https://www.eventbrite.com/e/tts-info-session-centers-of-excellence-tickets-168762919435)
+* [Thursday, September 23 at 12:30 pm EDT / 9:30 am PDT](https://www.eventbrite.com/e/tts-talent-info-session-tickets-169179268747)
 
+##### Centers of Excellence Director info sessions
+
+* [Tuesday, September 14th at 12:00 pm EDT / 9:00 am PDT](https://www.eventbrite.com/e/tts-info-session-centers-of-excellence-tickets-168755222413)
+* [Monday, September 20th at 5:00 pm EDT / 2:00 pm PDT](https://www.eventbrite.com/e/tts-info-session-centers-of-excellence-tickets-168762668685)
+* [Thursday, September 23rd at 9:00 am EDT / 6:00 am PDT](https://www.eventbrite.com/e/tts-info-session-centers-of-excellence-tickets-168762919435)
+
+##### 18F Chapter Directors info sessions
+
+* [Friday, September 17th at 2:00 pm EDT / 11:00 am PDT](https://www.eventbrite.com/e/18f-chapter-director-account-management-info-session-tickets-170477045432)
+* [Tuesday, September 21st at 5:00 pm EDT / 2:00 pm PDT](https://www.eventbrite.com/e/18f-chapter-director-account-management-info-session-tickets-170477922054)
 
 ### Upcoming Positions
 

--- a/pages/performance-profiles/18f-account-management-director.md
+++ b/pages/performance-profiles/18f-account-management-director.md
@@ -10,6 +10,11 @@ related_performance_profiles:
     link: /join/performance-profiles/18f-product-director/
   - name: '18F Design Director'
     link: /join/performance-profiles/18f-design-director/
+info_sessions:
+  - text: 'Friday, September 17th at 2:00 pm EDT / 11:00 am PDT'
+    link: 'https://www.eventbrite.com/e/18f-chapter-director-account-management-info-session-tickets-170477045432'
+  - text: 'Tuesday, September 21st at 5:00 pm EDT / 2:00 pm PDT'
+    link: 'https://www.eventbrite.com/e/18f-chapter-director-account-management-info-session-tickets-170477922054'
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter director
@@ -26,7 +31,7 @@ org: 18F
 {% endif %}
 
 ## Attend an information session
-Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. 
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process.
 {% if page.info_sessions %}
 Register for a session using the Eventbrite links below.
 {% for session in page.info_sessions %}
@@ -39,53 +44,53 @@ These sessions are not yet scheduled. We'll post dates and registration links he
 ## Role summary
 
 18F delivers agile IT procurement, software design and development, and consulting services to agency partners across government. We use an iterative, user-centered approach to help our government partners modernize technology and build capacity for innovation. 18F chapter directors foster inclusion, belonging, and growth within their teams. In this role, you’ll help shape how 18F creates meaningful change for our partners, stakeholders, and the American public.  
-The 18F Account Management Director leads the 18F chapter focused on creating and maintaining partnerships with government agencies and programs. You’ll support employee development, lead hiring for 18F’s Account Management chapter, set a vision for the chapter, and represent the Account Management chapter as a member of 18F leadership. 
+The 18F Account Management Director leads the 18F chapter focused on creating and maintaining partnerships with government agencies and programs. You’ll support employee development, lead hiring for 18F’s Account Management chapter, set a vision for the chapter, and represent the Account Management chapter as a member of 18F leadership.
 
 You’ll support a team of Account Managers, who are:
-- Experienced leaders, playing a critical strategic role on project teams. It is not a junior role, though it is the least hands-on role within any project team. 
+- Experienced leaders, playing a critical strategic role on project teams. It is not a junior role, though it is the least hands-on role within any project team.
 - Essential to the business development (BD), agreements, and pre-flight phases of a project
 - Key holders of partner relationships
 - Keepers of institutional knowledge
-- An important player in our project delivery and quality assurance processes 
+- An important player in our project delivery and quality assurance processes
 
 ## Key objectives
 
 ### Objective #1: Provide coaching, mentorship, and professional development opportunities; support employee wellbeing
--  Assign work to chapter members based on priorities, selective consideration of the difficulty and requirements of assignments, and the capabilities of employees. 
--  Ensure continued technical excellence in your chapter. 
--  Communicate regularly with your team, as a group and in 1:1s, to provide mentorship and guidance, and help remove obstacles to their success. 
--  Steward the Account Management chapter’s professional development by identifying appropriate training, developmental assignments, and/or details. Incorporate equity and inclusion into training, speaking events, and experiential learning opportunities. Tailor approaches to individuals’ needs. 
--  Work with individuals to identify and develop their strengths, helping team members pursue opportunities that enhance their talents. 
--  Constructively address situations, issues, and behaviors. Initiate difficult conversations and clearly communicate corrective actions. 
--  Recognize and flag stress and fatigue in your chapter. Work with individuals to determine support that might improve their wellbeing. Determine mechanisms to provide that support. 
--  Collaborate with other members of 18F leadership to identify and support strategic training opportunities. 
--  Ensure employees receive reasonable accommodations and that team events are accessible. 
--  Support the onboarding of new Account Management chapter staff. 
--  Conduct and document employee performance plans, mid-year, and end-of-year performance evaluations. 
+-  Assign work to chapter members based on priorities, selective consideration of the difficulty and requirements of assignments, and the capabilities of employees.
+-  Ensure continued technical excellence in your chapter.
+-  Communicate regularly with your team, as a group and in 1:1s, to provide mentorship and guidance, and help remove obstacles to their success.
+-  Steward the Account Management chapter’s professional development by identifying appropriate training, developmental assignments, and/or details. Incorporate equity and inclusion into training, speaking events, and experiential learning opportunities. Tailor approaches to individuals’ needs.
+-  Work with individuals to identify and develop their strengths, helping team members pursue opportunities that enhance their talents.
+-  Constructively address situations, issues, and behaviors. Initiate difficult conversations and clearly communicate corrective actions.
+-  Recognize and flag stress and fatigue in your chapter. Work with individuals to determine support that might improve their wellbeing. Determine mechanisms to provide that support.
+-  Collaborate with other members of 18F leadership to identify and support strategic training opportunities.
+-  Ensure employees receive reasonable accommodations and that team events are accessible.
+-  Support the onboarding of new Account Management chapter staff.
+-  Conduct and document employee performance plans, mid-year, and end-of-year performance evaluations.
 
 ### Objective #2: Provide strategic leadership
--  Serve on the 18F senior management team, which is responsible for operations of the business, employee management, and providing strategic leadership to staff. 
+-  Serve on the 18F senior management team, which is responsible for operations of the business, employee management, and providing strategic leadership to staff.
 -  Work to develop and maintain program components in all areas of operations and delivery, including marketing, sales, performance management, organizational compliance, project success, and partner relationships.
 -  Use data-driven decision making to make strategic decisions on behalf of the organization.
 -  Solicit input from staff members and communicates decisions and plans to staff in a transparent manner.
 -  Provide advice to other members of the Senior Management Team, and advise the Executive Director on key operational and delivery decisions.
 -  Facilitate partnerships with stakeholders, establishing effective internal and external lines of communications, seeking and advising senior level officials on best practices and coordinating meetings, working groups designed to improve TTS practices.
 -  Collect feedback to discuss successes and challenges, and share patterns and key feedback with the rest of 18F leadership
--  Represent the chapter in the 18F Senior Management Team (SMT) and communicate information back to the chapter. Promote transparency in how decisions are made. Regularly include others in planning and decision-making. 
--  Create a work environment that fosters trust, respect, and collaboration, since the best work comes from including diverse skill sets and backgrounds. Uphold TTS values of inclusion, integrity, and impact. 
--  Identify power dynamics in situations; respond thoughtfully and open space for less powerful voices. 
+-  Represent the chapter in the 18F Senior Management Team (SMT) and communicate information back to the chapter. Promote transparency in how decisions are made. Regularly include others in planning and decision-making.
+-  Create a work environment that fosters trust, respect, and collaboration, since the best work comes from including diverse skill sets and backgrounds. Uphold TTS values of inclusion, integrity, and impact.
+-  Identify power dynamics in situations; respond thoughtfully and open space for less powerful voices.
 -  Promote collective success; plan and ensure there is time for collaborative decision-making; acknowledge how others’ contributions led to achievements; and create shared ownership of success, risks, and accountability.
--  Craft strategic, data-driven hiring plans for the Product chapter that align with TTS’s hiring strategy and trends in partner needs. Include sourcing strategies and interview practices to ensure a diverse candidate pool and inclusive hiring process. Our goal is for our team to reflect the diversity of the American public. 
--  Ensure Equal Employment Opportunity (EEO) regulations are followed throughout recruitment, hiring, and selection processes. 
--  Set strategy for knowledge management such that key information is carried forward, to make the chapter resilient to turnover. 
+-  Craft strategic, data-driven hiring plans for the Product chapter that align with TTS’s hiring strategy and trends in partner needs. Include sourcing strategies and interview practices to ensure a diverse candidate pool and inclusive hiring process. Our goal is for our team to reflect the diversity of the American public.
+-  Ensure Equal Employment Opportunity (EEO) regulations are followed throughout recruitment, hiring, and selection processes.
+-  Set strategy for knowledge management such that key information is carried forward, to make the chapter resilient to turnover.
 
 ### Objective #3: Support 18F project teams and build stronger organization-wide practices
--  Help 18F teams align on and adhere to shared processes, maintain high standards, and resolve conflicts. Connect teams to resources, amplify team successes, and help teams to pivot or adapt as needed. 
--  Help 18F project teams understand what success looks like. Work with project teams to regularly demonstrate our expertise and impact. 
+-  Help 18F teams align on and adhere to shared processes, maintain high standards, and resolve conflicts. Connect teams to resources, amplify team successes, and help teams to pivot or adapt as needed.
+-  Help 18F project teams understand what success looks like. Work with project teams to regularly demonstrate our expertise and impact.
 -  As part of 18F leadership, provide oversight of partner engagements and help members of the Account Management chapter contribute meaningfully to partner and user success.
 -  Collaborate with SMT and staffing leads to ensure projects are staffed with Account Management chapter expertise to best meet the needs of partners as well as to support skills growth of team members.
--  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives. 
--  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press. 
+-  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives.
+-  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press.
 
 ## Three {{ page.org }} teams are hiring for this role
 

--- a/pages/performance-profiles/18f-design-director.md
+++ b/pages/performance-profiles/18f-design-director.md
@@ -10,6 +10,11 @@ related_performance_profiles:
     link: /join/performance-profiles/18f-product-director/
   - name: '18F Account Management Director'
     link: /join/performance-profiles/18f-account-management-director/
+info_sessions:
+  - text: 'Friday, September 17th at 2:00 pm EDT / 11:00 am PDT'
+    link: 'https://www.eventbrite.com/e/18f-chapter-director-account-management-info-session-tickets-170477045432'
+  - text: 'Tuesday, September 21st at 5:00 pm EDT / 2:00 pm PDT'
+    link: 'https://www.eventbrite.com/e/18f-chapter-director-account-management-info-session-tickets-170477922054'
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter director
@@ -26,7 +31,7 @@ org: 18F
 {% endif %}
 
 ## Attend an information session
-Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. 
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process.
 {% if page.info_sessions %}
 Register for a session using the Eventbrite links below.
 {% for session in page.info_sessions %}
@@ -38,45 +43,45 @@ These sessions are not yet scheduled. We'll post dates and registration links he
 
 ## Role summary
 
-18F delivers agile IT procurement, software design and development, and consulting services to agency partners across government. We use an iterative, user-centered approach to help our government partners modernize technology and build capacity for innovation. 18F chapter directors foster inclusion, belonging, and growth within their teams. In this role, you’ll help shape how 18F creates meaningful change for our partners, stakeholders, and the American public. 
-The 18F Design Director sets the vision for design work on cross-functional teams to deliver digital products & services. You’ll lead the 18F Design chapter in all aspects of design at 18F, including product design, experience design, user research, content strategy, service design, and organizational design. You’ll support employee development, lead hiring for 18F’s Design chapter, set a vision for the chapter, and represent the Design chapter as a member of 18F leadership. 
+18F delivers agile IT procurement, software design and development, and consulting services to agency partners across government. We use an iterative, user-centered approach to help our government partners modernize technology and build capacity for innovation. 18F chapter directors foster inclusion, belonging, and growth within their teams. In this role, you’ll help shape how 18F creates meaningful change for our partners, stakeholders, and the American public.
+The 18F Design Director sets the vision for design work on cross-functional teams to deliver digital products & services. You’ll lead the 18F Design chapter in all aspects of design at 18F, including product design, experience design, user research, content strategy, service design, and organizational design. You’ll support employee development, lead hiring for 18F’s Design chapter, set a vision for the chapter, and represent the Design chapter as a member of 18F leadership.
 
 ## Key objectives
 
 ### Objective #1: Provide coaching, mentorship, and professional development opportunities; support employee wellbeing
-- Ensure continued technical excellence in your chapter. 
--  Collaborate with other members of 18F leadership to identify and support strategic training opportunities. 
--  Communicate regularly with your team, as a group and in 1:1s, to provide mentorship and guidance, and help remove obstacles to their success. 
--  Steward the Design chapter’s professional development by identifying appropriate training, developmental assignments, and/or details. Incorporate equity and inclusion into training, speaking events, and experiential learning opportunities. Tailor approaches to individuals’ needs. 
--  Work with individuals to identify and develop their strengths, helping team members pursue opportunities that enhance their talents. 
--  Constructively address situations, issues, and behaviors. Initiate difficult conversations and clearly communicate corrective actions. 
--  Recognize and flag stress and fatigue in your chapter. Work with individuals to determine support that might improve their wellbeing. Determine mechanisms to provide that support. 
--  Ensure employees receive reasonable accommodations and that team events are accessible. 
+- Ensure continued technical excellence in your chapter.
+-  Collaborate with other members of 18F leadership to identify and support strategic training opportunities.
+-  Communicate regularly with your team, as a group and in 1:1s, to provide mentorship and guidance, and help remove obstacles to their success.
+-  Steward the Design chapter’s professional development by identifying appropriate training, developmental assignments, and/or details. Incorporate equity and inclusion into training, speaking events, and experiential learning opportunities. Tailor approaches to individuals’ needs.
+-  Work with individuals to identify and develop their strengths, helping team members pursue opportunities that enhance their talents.
+-  Constructively address situations, issues, and behaviors. Initiate difficult conversations and clearly communicate corrective actions.
+-  Recognize and flag stress and fatigue in your chapter. Work with individuals to determine support that might improve their wellbeing. Determine mechanisms to provide that support.
+-  Ensure employees receive reasonable accommodations and that team events are accessible.
 -  Support the onboarding of new Design chapter staff.
--  Conduct and document employee performance plans, mid-year, and end-of-year performance evaluations. 
+-  Conduct and document employee performance plans, mid-year, and end-of-year performance evaluations.
 
 ### Objective #2: Provide strategic leadership
-- Set the vision for the 18F Design chapter, aligning with 18F / TTS vision, goals, and values. 
--  Lead strategic 18F initiatives. 
--  Coordinate with other members of the 18F leadership team to develop guidance and organizational communication. 
--  Collect feedback to discuss successes and challenges, and share patterns and key feedback with the rest of 18F leadership. 
--  Represent the chapter in the 18F Senior Management Team (SMT) and communicate information back to the chapter. Promote transparency in how decisions are made. Regularly include others in planning and decision-making. 
--  Create a work environment that fosters trust, respect, and collaboration, since the best work comes from including diverse skill sets and backgrounds. Uphold TTS values of inclusion, integrity, and impact. 
--  Identify power dynamics in situations; respond thoughtfully and open space for less powerful voices. 
+- Set the vision for the 18F Design chapter, aligning with 18F / TTS vision, goals, and values.
+-  Lead strategic 18F initiatives.
+-  Coordinate with other members of the 18F leadership team to develop guidance and organizational communication.
+-  Collect feedback to discuss successes and challenges, and share patterns and key feedback with the rest of 18F leadership.
+-  Represent the chapter in the 18F Senior Management Team (SMT) and communicate information back to the chapter. Promote transparency in how decisions are made. Regularly include others in planning and decision-making.
+-  Create a work environment that fosters trust, respect, and collaboration, since the best work comes from including diverse skill sets and backgrounds. Uphold TTS values of inclusion, integrity, and impact.
+-  Identify power dynamics in situations; respond thoughtfully and open space for less powerful voices.
 -  Promote collective success; plan and ensure there is time for collaborative decision-making; acknowledge how others’ contributions led to achievements; and create shared ownership of success, risks, and accountability.
--  Identify 18F and Design chapter processes in need of improvement and oversee improvement activities. 
--  Research, develop, and encourage best practices in the sub-disciplines of design and user research, and create space for experimentation and iteration. 
--  Craft strategic, data-driven hiring plans for the Design chapter that align with TTS’s hiring strategy and trends in partner needs. Include sourcing strategies and interview practices to ensure a diverse candidate pool and inclusive hiring process. Our goal is for our team to reflect the diversity of the American public. 
--  Ensure Equal Employment Opportunity (EEO) regulations are followed throughout recruitment, hiring, and selection processes. 
+-  Identify 18F and Design chapter processes in need of improvement and oversee improvement activities.
+-  Research, develop, and encourage best practices in the sub-disciplines of design and user research, and create space for experimentation and iteration.
+-  Craft strategic, data-driven hiring plans for the Design chapter that align with TTS’s hiring strategy and trends in partner needs. Include sourcing strategies and interview practices to ensure a diverse candidate pool and inclusive hiring process. Our goal is for our team to reflect the diversity of the American public.
+-  Ensure Equal Employment Opportunity (EEO) regulations are followed throughout recruitment, hiring, and selection processes.
 -  Set strategy for knowledge management such that key information is carried forward, to make the chapter resilient to turnover.
 
 ### Objective #3: Support 18F project teams and build stronger organization-wide practices
--  Help 18F teams align on and adhere to shared processes, maintain high standards, and resolve conflicts. Connect teams to resources, amplify team successes, and help teams to pivot or adapt as needed. 
--  Help 18F project teams understand what success looks like. Work with project teams to regularly demonstrate our expertise and impact. 
+-  Help 18F teams align on and adhere to shared processes, maintain high standards, and resolve conflicts. Connect teams to resources, amplify team successes, and help teams to pivot or adapt as needed.
+-  Help 18F project teams understand what success looks like. Work with project teams to regularly demonstrate our expertise and impact.
 -  As part of 18F leadership, provide oversight of partner engagements and help members of the Design chapter contribute meaningfully to partner and user success.
 -  Collaborate with SMT and staffing leads to ensure projects are staffed with Design chapter expertise to best meet the needs of partners as well as to support skills growth of team members.
--  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives. 
--  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press. 
+-  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives.
+-  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press.
 
 ## Three {{ page.org }} teams are hiring for this role
 

--- a/pages/performance-profiles/18f-product-director.md
+++ b/pages/performance-profiles/18f-product-director.md
@@ -1,5 +1,5 @@
 ---
-title: 18F Product director 
+title: 18F Product director
 permalink: /join/performance-profiles/18f-product-director/
 state: upcoming
 job_post_type: usajobs
@@ -10,6 +10,11 @@ related_performance_profiles:
     link: /join/performance-profiles/18f-design-director/
   - name: '18F Account Management Director'
     link: /join/performance-profiles/18f-account-management-director/
+info_sessions:
+  - text: 'Friday, September 17th at 2:00 pm EDT / 11:00 am PDT'
+    link: 'https://www.eventbrite.com/e/18f-chapter-director-account-management-info-session-tickets-170477045432'
+  - text: 'Tuesday, September 21st at 5:00 pm EDT / 2:00 pm PDT'
+    link: 'https://www.eventbrite.com/e/18f-chapter-director-account-management-info-session-tickets-170477922054'
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter director
@@ -26,7 +31,7 @@ org: 18F
 {% endif %}
 
 ## Attend an information session
-Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. 
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process.
 {% if page.info_sessions %}
 Register for a session using the Eventbrite links below.
 {% for session in page.info_sessions %}
@@ -38,45 +43,45 @@ These sessions are not yet scheduled. We'll post dates and registration links he
 
 ## Role summary
 
-18F delivers agile IT procurement, software design and development, and consulting services to agency partners across government. We use an iterative, user-centered approach to help our government partners modernize technology and build capacity for innovation. 18F chapter directors foster inclusion, belonging, and growth within their teams. In this role, you’ll help shape how 18F creates meaningful change for our partners, stakeholders, and the American public. 
-The 18F Product Director leads the 18F chapter focused on driving products from concept to delivery. 18F product managers are strategic thinkers who are comfortable defining a compelling vision and designing a measurable strategy to achieve that vision. You’ll support employee development, lead hiring for 18F’s Product chapter, set a vision for the chapter, and represent the Product chapter as a member of 18F leadership. 
+18F delivers agile IT procurement, software design and development, and consulting services to agency partners across government. We use an iterative, user-centered approach to help our government partners modernize technology and build capacity for innovation. 18F chapter directors foster inclusion, belonging, and growth within their teams. In this role, you’ll help shape how 18F creates meaningful change for our partners, stakeholders, and the American public.
+The 18F Product Director leads the 18F chapter focused on driving products from concept to delivery. 18F product managers are strategic thinkers who are comfortable defining a compelling vision and designing a measurable strategy to achieve that vision. You’ll support employee development, lead hiring for 18F’s Product chapter, set a vision for the chapter, and represent the Product chapter as a member of 18F leadership.
 
 ## Key objectives
 
 ### Objective #1: Provide coaching, mentorship, and professional development opportunities; support employee wellbeing
--  Ensure continued technical excellence in your chapter. 
--  Communicate regularly with your team, as a group and in 1:1s, to provide mentorship and guidance, and help remove obstacles to their success. 
--  Steward the Product chapter’s professional development by identifying appropriate training, developmental assignments, and/or details. Incorporate equity and inclusion into training, speaking events, and experiential learning opportunities. Tailor approaches to individuals’ needs. 
--  Work with individuals to identify and develop their strengths, helping team members pursue opportunities that enhance their talents. 
--  Constructively address situations, issues, and behaviors. Initiate difficult conversations and clearly communicate corrective actions. 
--  Recognize and flag stress and fatigue in your chapter. Work with individuals to determine support that might improve their wellbeing. Determine mechanisms to provide that support. 
--  Collaborate with other members of 18F leadership to identify and support strategic training opportunities. 
--  Ensure employees receive reasonable accommodations and that team events are accessible. 
--  Support the onboarding of new Product chapter staff. 
--  Conduct and document employee performance plans, mid-year, and end-of-year performance evaluations. 
+-  Ensure continued technical excellence in your chapter.
+-  Communicate regularly with your team, as a group and in 1:1s, to provide mentorship and guidance, and help remove obstacles to their success.
+-  Steward the Product chapter’s professional development by identifying appropriate training, developmental assignments, and/or details. Incorporate equity and inclusion into training, speaking events, and experiential learning opportunities. Tailor approaches to individuals’ needs.
+-  Work with individuals to identify and develop their strengths, helping team members pursue opportunities that enhance their talents.
+-  Constructively address situations, issues, and behaviors. Initiate difficult conversations and clearly communicate corrective actions.
+-  Recognize and flag stress and fatigue in your chapter. Work with individuals to determine support that might improve their wellbeing. Determine mechanisms to provide that support.
+-  Collaborate with other members of 18F leadership to identify and support strategic training opportunities.
+-  Ensure employees receive reasonable accommodations and that team events are accessible.
+-  Support the onboarding of new Product chapter staff.
+-  Conduct and document employee performance plans, mid-year, and end-of-year performance evaluations.
 
 ###  Objective #2: Provide strategic leadership
--  Set the vision for the 18F Product chapter, aligning with 18F / TTS vision, goals, and values. 
--  Lead strategic 18F initiatives. 
--  Coordinate with other members of the 18F leadership team to develop guidance and organizational communication. 
--  Collect feedback to discuss successes and challenges, and share patterns and key feedback with the rest of 18F leadership. 
--  Represent the chapter in the 18F Senior Management Team (SMT) and communicate information back to the chapter. Promote transparency in how decisions are made. Regularly include others in planning and decision-making. 
--  Create a work environment that fosters trust, respect, and collaboration, since the best work comes from including diverse skill sets and backgrounds. Uphold TTS values of inclusion, integrity, and impact. 
--  Identify power dynamics in situations; respond thoughtfully and open space for less powerful voices. 
+-  Set the vision for the 18F Product chapter, aligning with 18F / TTS vision, goals, and values.
+-  Lead strategic 18F initiatives.
+-  Coordinate with other members of the 18F leadership team to develop guidance and organizational communication.
+-  Collect feedback to discuss successes and challenges, and share patterns and key feedback with the rest of 18F leadership.
+-  Represent the chapter in the 18F Senior Management Team (SMT) and communicate information back to the chapter. Promote transparency in how decisions are made. Regularly include others in planning and decision-making.
+-  Create a work environment that fosters trust, respect, and collaboration, since the best work comes from including diverse skill sets and backgrounds. Uphold TTS values of inclusion, integrity, and impact.
+-  Identify power dynamics in situations; respond thoughtfully and open space for less powerful voices.
 -  Promote collective success; plan and ensure there is time for collaborative decision-making; acknowledge how others’ contributions led to achievements; and create shared ownership of success, risks, and accountability.
--  Identify 18F and Product chapter processes in need of improvement and oversee improvement activities. 
--  Research, develop, and encourage best practices in the field of product management, and create space for experimentation and iteration. 
--  Craft strategic, data-driven hiring plans for the Product chapter that align with TTS’s hiring strategy and trends in partner needs. Include sourcing strategies and interview practices to ensure a diverse candidate pool and inclusive hiring process. Our goal is for our team to reflect the diversity of the American public. 
--  Ensure Equal Employment Opportunity (EEO) regulations are followed throughout recruitment, hiring, and selection processes. 
--  Set strategy for knowledge management such that key information is carried forward, to make the chapter resilient to turnover. 
+-  Identify 18F and Product chapter processes in need of improvement and oversee improvement activities.
+-  Research, develop, and encourage best practices in the field of product management, and create space for experimentation and iteration.
+-  Craft strategic, data-driven hiring plans for the Product chapter that align with TTS’s hiring strategy and trends in partner needs. Include sourcing strategies and interview practices to ensure a diverse candidate pool and inclusive hiring process. Our goal is for our team to reflect the diversity of the American public.
+-  Ensure Equal Employment Opportunity (EEO) regulations are followed throughout recruitment, hiring, and selection processes.
+-  Set strategy for knowledge management such that key information is carried forward, to make the chapter resilient to turnover.
 
 ###  Objective #3: Support 18F project teams and build stronger organization-wide practices
--  Help 18F teams align on and adhere to shared processes, maintain high standards, and resolve conflicts. Connect teams to resources, amplify team successes, and help teams to pivot or adapt as needed. 
--  Help 18F project teams understand what success looks like. Work with project teams to regularly demonstrate our expertise and impact. 
+-  Help 18F teams align on and adhere to shared processes, maintain high standards, and resolve conflicts. Connect teams to resources, amplify team successes, and help teams to pivot or adapt as needed.
+-  Help 18F project teams understand what success looks like. Work with project teams to regularly demonstrate our expertise and impact.
 -  As part of 18F leadership, provide oversight of partner engagements and help members of the Product chapter contribute meaningfully to partner and user success.
 -  Collaborate with SMT and staffing leads to ensure projects are staffed with Product chapter expertise to best meet the needs of partners as well as to support skills growth of team members.
--  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives. 
--  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press. 
+-  Participate in and lead client-facing work and business development efforts, generally up to 20% time weekly, depending on availability based on other initiatives.
+-  Represent 18F to external parties, such as speaking at conferences, writing blogs, or speaking to the press.
 
 ## Three {{ page.org }} teams are hiring for this role
 

--- a/pages/positions/bucket-18f-chapter-directors.md
+++ b/pages/positions/bucket-18f-chapter-directors.md
@@ -1,5 +1,5 @@
 ---
-title: 18F Chapter Directors 
+title: 18F Chapter Directors
 permalink: /join/bucket-18f-chapter-directors/
 state: upcoming
 job_post_type: usajobs
@@ -10,6 +10,11 @@ related_performance_profiles:
     link: /join/performance-profiles/18f-product-director/
   - name: '18F Account Management Director'
     link: /join/performance-profiles/18f-account-management-director/
+info_sessions:
+  - text: 'Friday, September 17th at 2:00 pm EDT / 11:00 am PDT'
+    link: 'https://www.eventbrite.com/e/18f-chapter-director-account-management-info-session-tickets-170477045432'
+  - text: 'Tuesday, September 21st at 5:00 pm EDT / 2:00 pm PDT'
+    link: 'https://www.eventbrite.com/e/18f-chapter-director-account-management-info-session-tickets-170477922054'
 
 # INSTRUCTIONS UPCOMING: These fields are required for upcoming
 role_name: Chapter Director
@@ -40,11 +45,11 @@ contact_email: 'jointts@gsa.gov'
 {{ page.org }} will soon be accepting applications for GS-{{ page.gs_level }} - {{ page.role_name }} roles.
   {% if page.opens == 'tbd' %} The target date for when these positions will be officially open to application has not yet been determined. If you'd like to be
   notified when these positions are open, sign up to our [mailing list]({{ site.baseurl }}/newsletter).
-  {% else %} 
-  Applications will be open for submission on {{ page.opens | date: '%A, %B %e, %Y' }}. 
+  {% else %}
+  Applications will be open for submission on {{ page.opens | date: '%A, %B %e, %Y' }}.
   {% endif %}
   Check out [Join TTS Hiring Process]({{site.baseurl}}/hiring-process/) to
-  learn more about the application process. 
+  learn more about the application process.
 {% endif %}
 
 {% if page.state != 'upcoming' %}
@@ -52,7 +57,7 @@ contact_email: 'jointts@gsa.gov'
 {% endif %}
 
 ## Attend an information session
-Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process. 
+Attend an information session to learn more about these roles, working at {{ page.org }}, and our application process.
 {% if page.info_sessions %}
 Register for a session using the Eventbrite links below.
 {% for session in page.info_sessions %}
@@ -64,7 +69,7 @@ These sessions are not yet scheduled. We'll post dates and registration links he
 
 ## Opportunity overview
 
-These opportunities are located in the General Services Administration (GSA), Federal Acquisition Service (FAS), Technology Transformation Services (TTS), Office of 18F. 18F helps other government agencies build, buy, and share technology products. 
+These opportunities are located in the General Services Administration (GSA), Federal Acquisition Service (FAS), Technology Transformation Services (TTS), Office of 18F. 18F helps other government agencies build, buy, and share technology products.
 18F envisions a country whose government consistently offers digital services that instill pride and trust, meet user needs, are secure, and are delivered quickly and at reasonable cost.
 
 18F develops partnerships with agencies to help them deliver exceptional digital experiences that address their strategic initiatives. Through our work together, we aim to strengthen government technology practices in ways that last beyond our formal partnerships. We effect change by practicing user-centered development, testing to validate hypotheses, shipping often, and deploying products in the open.
@@ -73,14 +78,14 @@ These opportunities are located in the General Services Administration (GSA), Fe
 
 Chapter Directors:
 - Support growth of their teams’ ability to deliver partner success
-- Help deliver partner success 
+- Help deliver partner success
 - Create and cultivate strong partnerships with TTS government partners
 - Own significant parts of the engagement or business development / sales cycle
 - Oversee and advise on project delivery
 
 ## {{ page.org }} teams hiring for this role
 
-**There are several {{ page.org }} teams hiring for this role.** The links below provide more specific descriptions of these opportunities. 
+**There are several {{ page.org }} teams hiring for this role.** The links below provide more specific descriptions of these opportunities.
 
 {% for profile in page.related_performance_profiles %}
   - [{{profile.name}}]({{site.baseurl}}{{profile.link}})
@@ -103,7 +108,7 @@ You can find more information about this in the [compensation and benefits secti
 For specific details on locality pay, please visit [OPM's Salaries & Wages page](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/) or for a
 salary calculator [OPM's 2021 General Schedule (GS) Salary Calculator](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2021/general-schedule-gs-salary-calculator/).
 
-Please note the maximum salary available for the GS pay system is **$172,500** 
+Please note the maximum salary available for the GS pay system is **$172,500**
 
 Note: You may not be eligible for the maximum salary as it is locality dependent. Please refer to the maximum pay for your locality.
 


### PR DESCRIPTION
Fixes issue(s) # .

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/add-18f-chapter-directors-info-sessions/)

Changes proposed in this pull request:
- Landing page has info sessions broken out by headings for org/role, with links to the sessions
- 18F Chapter Directors has links to the sessions
- Each chapter director performance profile also has links to the role


