### PR TITLE
remove the auto-populate of info sessions on landing page

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -69,11 +69,6 @@ We hold periodic info sessions to offer potential candidates an opportunity to l
 {% unless pg.path contains 'template' %}
 {% unless pg.path contains 'performance-profiles' %}
 * [{{ pg.title }}]({{ site.baseurl }}{{ pg.permalink }})
-{% if pg.info_sessions %}
-{% for session in pg.info_sessions %}
-    * {{ pg.title }} info session, [{{ session.date }}, at {{ session.time }}]({{ session.link }})
-{% endfor %}
-{% endif %}
 {% endunless %}
 {% endunless %}
 {% endif %}


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/fix-bucket-page-weird-text/)

Changes proposed in this pull request:
- Remove the auto-populate of info sessions on landing page because there aren't consistently variables on position pages
