### PR TITLE
Fix typo on hiring process page

### DIFF
--- a/pages/hiring-process.md
+++ b/pages/hiring-process.md
@@ -119,7 +119,7 @@ We realize video chats aren’t an option for everyone, so we are also happy to
 work with a candidate’s individual needs to ensure they have a good interviewing
 experience and can use their preferred method of communication.
 
-### Accomodations
+### Accommodations
 
 We want to interview you at your best, and we’re more than happy to provide
 reasonable accommodations to support that! Let us know if there are


### PR DESCRIPTION
`Accomodations` --> `Accommodations`

Relates to issue #212.

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/BRANCH_NAME/)

Changes proposed in this pull request:
- Change `Accomodations` to `Accommodations`

/cc @nickttng (...? That's my best guess from reading #212. Thanks in advance!)