### PR TITLE
Use absolute URLs for social images

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -23,10 +23,10 @@
 <meta name="twitter:description" content="{{ description }}">
 {% endif %}
 
-<meta property="og:url" content="{{ site.url }}{{ page.url }}">
-<meta property="og:image" content="{{ site.url }}/assets/img/social-share.jpg">
+<meta property="og:url" content="{{ page.url | absolute_url }}">
+<meta property="og:image" content="{{ '/assets/img/social-share.jpg' | absolute_url }}">
 <meta property="og:image:alt" content="An illustration of a group of people of various races, genders, dress, and mobilities talking to one another, some holding phones and computers. To the left of the group are the words ‘We’re hiring, join us!’ with the General Services Administration logo beneath.">
-<meta name="twitter:image" content="{{ site.url }}/assets/img/social-share.jpg">
+<meta name="twitter:image" content="{{ '/assets/img/social-share.jpg' | absolute_url }}">
 <meta name="twitter:image:alt" content="An illustration of a group of people of various races, genders, dress, and mobilities talking to one another, some holding phones and computers. To the left of the group are the words ‘We’re hiring, join us!’ with the General Services Administration logo beneath.">
 
 <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
Right now social previews are broken in production. This was introduced in #692, though I'm not sure why. This PR attempts to fix what I think is the underlying problem.

Before, we were creating social image URLs and the Open Graph URL tags
from the site.url, which is nil in production environments. As a result,
these paths were relative when they need to be absolute. Also, the
og:url attribute is supposed to be unique, since it is used for
indexing.

This PR converts the relative paths into absolutes using the
absolute_url Jekyll helper.

For reference, here is the Login.gov meta tags: https://github.com/18F/identity-site/blob/a58dab9c4b91317d438ebf731346d170e86b0338/_includes/meta.html

Fixes issue(s) #691 

/cc @laurenferrucci
