### PR TITLE
Use absolute URLs for social images

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 title: Join the Technology Transformation Services
 description: The Technology Transformation Service’s (TTS) mission is to lead the digital transformation of the federal government by helping agencies build, buy, and share technology that allows them to provide more accessible, efficient, and effective products and services to the American people.
+url: https://join.tts.gsa.gov
 
 theme: uswds-jekyll
 

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -25,9 +25,9 @@
 
 <meta property="og:url" content="{{ page.url | absolute_url }}">
 <meta property="og:image" content="{{ '/assets/img/social-share.jpg' | absolute_url }}">
-<meta property="og:image:alt" content="An illustration of a group of people of various races, genders, dress, and mobilities talking to one another, some holding phones and computers. To the left of the group are the words ‘We’re hiring, join us!’ with the General Services Administration logo beneath.">
+<meta property="og:image:alt" content="An illustration of a group of people of various races, genders, dress, and disabilities talking to one another, some holding phones and computers. To the left of the group are the words ‘We’re hiring, join us!’ with the General Services Administration logo beneath.">
 <meta name="twitter:image" content="{{ '/assets/img/social-share.jpg' | absolute_url }}">
-<meta name="twitter:image:alt" content="An illustration of a group of people of various races, genders, dress, and mobilities talking to one another, some holding phones and computers. To the left of the group are the words ‘We’re hiring, join us!’ with the General Services Administration logo beneath.">
+<meta name="twitter:image:alt" content="An illustration of a group of people of various races, genders, dress, and disabilities talking to one another, some holding phones and computers. To the left of the group are the words ‘We’re hiring, join us!’ with the General Services Administration logo beneath.">
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@gsa_tts">

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -23,10 +23,10 @@
 <meta name="twitter:description" content="{{ description }}">
 {% endif %}
 
-<meta property="og:url" content="{{ site.url }}{{ page.url }}">
-<meta property="og:image" content="{{ site.url }}/assets/img/social-share.jpg">
+<meta property="og:url" content="{{ page.url | absolute_url }}">
+<meta property="og:image" content="{{ '/assets/img/social-share.jpg' | absolute_url }}">
 <meta property="og:image:alt" content="An illustration of a group of people of various races, genders, dress, and mobilities talking to one another, some holding phones and computers. To the left of the group are the words ‘We’re hiring, join us!’ with the General Services Administration logo beneath.">
-<meta name="twitter:image" content="{{ site.url }}/assets/img/social-share.jpg">
+<meta name="twitter:image" content="{{ '/assets/img/social-share.jpg' | absolute_url }}">
 <meta name="twitter:image:alt" content="An illustration of a group of people of various races, genders, dress, and mobilities talking to one another, some holding phones and computers. To the left of the group are the words ‘We’re hiring, join us!’ with the General Services Administration logo beneath.">
 
 <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
Right now social previews are broken in production. This was partially introduced in #692, though it seems that some social cards haven't been working for a bit. This PR attempts to fix what I think is the underlying problem, which is that we weren't setting site.url in the config.

Before, we were creating social image URLs and the Open Graph URL tags
from the site.url, which is nil in production environments if unset. As a result,
these paths were relative when they need to be absolute. Also, the
og:url attribute is supposed to be unique, since it is an [index in the graph](https://ogp.me/).

This PR sets the site.url to the production URL in the config (meaning it'll be the same across environments, except when Jekyll overrides it in development). The `absolute_url` liquid filter looks to site.url to construct the absolute URL.

For reference, here is the Login.gov meta tags: https://github.com/18F/identity-site/blob/a58dab9c4b91317d438ebf731346d170e86b0338/_includes/meta.html and their _config.yml: https://github.com/18F/identity-site/blob/a58dab9c4b91317d438ebf731346d170e86b0338/_config.yml

Fixes issue(s) #691 

/cc @laurenferrucci