### PR TITLE
Fix bulleted list for Login.gov product manager role summary

### DIFF
--- a/pages/positions/login.gov-product-manager.md
+++ b/pages/positions/login.gov-product-manager.md
@@ -57,8 +57,9 @@ The Login.gov team is remote-first and is composed of experts across product dev
 As a Product Manager at [Login.gov](https://login.gov/), you’ll lead cross-functional teams to deliver user-centered products using agile methodologies and modern software development practices while building capacity for product innovation in government. 
 
 Product managers on our team are:
--Strategic thinkers who are comfortable defining a compelling vision and designing a measurable strategy to achieve that vision.
--Decisive leaders who know how to motivate cross-functional teams to build the right thing.
+
+- Strategic thinkers who are comfortable defining a compelling vision and designing a measurable strategy to achieve that vision.
+- Decisive leaders who know how to motivate cross-functional teams to build the right thing.
 
 ## Key objectives
 ### 1. Implement the product vision and lead end-to-end product development


### PR DESCRIPTION
Fixes bulleted list for role summary that is currently rendered as a paragraph.

![image](https://user-images.githubusercontent.com/1430443/206294163-e7ca0de3-7333-4946-95eb-6f7e6e511373.png)


<!-- 
Fixes issue(s) # .

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/BRANCH_NAME/)
-->