### PR TITLE
Update info_sessions.yml

### DIFF
--- a/_data/info_sessions.yml
+++ b/_data/info_sessions.yml
@@ -5,20 +5,10 @@
 # date: YYYY-MM-DD format. This will get parsed automatically to show day of the week and month name.
 # time: Time in 00:00 ET / 00:00 PT format. 
   
-- role: General
-  link: https://www.eventbrite.com/e/483337574697
-  date: 2023-01-19
-  time: 12:30-1:30pm ET (9:30-10:30am PT)  
-  
 - role: Login.gov Security Engineer Technical Expert GS15
   link: https://www.eventbrite.com/e/499487690127
-  date: 2023-01-19
-  time: 12:30-1:30pm ET (9:30-10:30am PT)
-  
-- role: Presidential Innovation Fellows Deputy Director GS15
-  link: https://www.eventbrite.com/e/pif-deputy-director-info-session-tickets-498694607997
-  date: 2023-01-19
-  time: 12:30-1:30pm ET (9:30-10:30am PT)
+  date: 2023-01-23
+  time: 2:00-3:00pm ET (11:00-12:00pm PT)
   
 - role: Login.gov Product Manager GS15
   link: https://www.eventbrite.com/e/logingov-product-manager-information-session-tickets-514949105637


### PR DESCRIPTION
- Remove 1/19 General & PIF Deputy Dir Info Sessions
- Reschedule Login Security Info Session from 1/19 12:30 ET to 1/23 2pm ET

Fixes issue(s) # .

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/BRANCH_NAME/)

Changes proposed in this pull request:
-
-
-

/cc @relevant-people
