### PR TITLE
Fix automatic archiver target branch

### DIFF
--- a/.github/workflows/archive_closed_jobs.yml
+++ b/.github/workflows/archive_closed_jobs.yml
@@ -54,7 +54,7 @@ jobs:
           git push -u origin $BRANCH
           echo -e "This pull request was created automatically. It is archiving job postings that are now closed. The pull request will merge automatically once it has been approved.\n\nApproving this pull request will move the following jobs into the archive:\n${{ steps.archive.outputs.archived_jobs }}\n\nNote: These jobs are already shown as CLOSED on the TTSJobs site. This pull request is not necessary to mark these jobs as closed. It is just for moving them to the archive to help keep a tidy repo. 🙂" > PR_BODY
           gh pr create \
-            --base mgwalker/1007-markdown-template \
+            --base main \
             --title "Archive closed jobs" \
             --body-file PR_BODY
 


### PR DESCRIPTION
The automatic archiver was configured to merge its changes into the `mgwalker/1007-...` branch, which was being used for development (in #1020). This PR updates the archiver to merge its changes into `main`, which is a real branch that exists.