### PR TITLE
Fix a typo on the home page

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -57,7 +57,7 @@ permalink: /
         </ul>
         {% else %}
           <p>
-            No open positions at this time. Check out our open roles or
+            No open positions at this time. Check out our upcoming roles or
             <a href="{% link pages/newsletter.md %}">sign up for job alerts</a>
             for future roles!
           </p>


### PR DESCRIPTION
If there are no open positions, the home page invites users to check out our open roles. It should instead invite them to check out our upcoming roles. This PR fixes that.