### PR TITLE
Update info session UI

### DIFF
--- a/_includes/info_sessions.html
+++ b/_includes/info_sessions.html
@@ -1,28 +1,14 @@
 {%- assign future_sessions = include.job | future_info_sessions_for_job -%} {%-
-if future_sessions.size > 0 -%} {% assign id = job.title | slugify | append:
-job.opens | append: "-info-sessions" %}
+if future_sessions.size > 0 -%}
 
-<div class="usa-accordion usa-accordion--bordered">
-  <h4 class="usa-accordion__heading">
-    <button
-      type="button"
-      class="usa-accordion__button"
-      aria-expanded="false"
-      aria-controls="{{ id }}"
-    >
-      Upcoming information sessions for {{ job.title }}
-    </button>
-  </h4>
-  <div id="{{ id }}" class="usa-accordion__content usa-prose">
-    <ul>
-      {% for session in future_sessions %}
-      <li>
-        <a href="{{ session.link }}">{{ session.date | human_friendly }}</a
-        ><br />at {{ session.time }}
-      </li>
-      {% endfor %}
-    </ul>
-  </div>
-</div>
+<h3>Upcoming info sessions</h3>
+<ul>
+  {% for session in future_sessions %}
+  <li>
+    <a href="{{ session.link }}">{{ session.date | human_friendly }}</a
+    ><br />at {{ session.time }}
+  </li>
+  {% endfor %}
+</ul>
 
 {%- endif -%}

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -133,15 +133,13 @@ $theme-color-accent-cool-lighter: #e1f3f8;
   }
 }
 
-.position-list.usa-prose > ul li.with-info-sessions {
-  margin-bottom: 1rem;
+.position-list.usa-prose {
+    &> ul li.with-info-sessions {
+    margin-bottom: 1rem;
 
-  button.usa-accordion__button {
-    background-color: #d9e8f6;
-  }
-
-  div.usa-accordion__content.usa-prose {
-    border-color: #d9e8f6;
+    h3 {
+      margin-bottom: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Much thanks to @melchoyce! Here's how info sessions associated with a job will now show up on the front page:

![screenshot of a portion of the TTS jobs front site](https://user-images.githubusercontent.com/1775733/218858026-b6e83721-b360-4240-be60-cf2812483f35.png)
