### PR TITLE
Enable auto-merge for archive PRs

### DIFF
--- a/.github/workflows/archive_closed_jobs.yml
+++ b/.github/workflows/archive_closed_jobs.yml
@@ -57,4 +57,5 @@ jobs:
             --base main \
             --title "Archive closed jobs" \
             --body-file PR_BODY
+          gh pr merge --auto --squash
 


### PR DESCRIPTION
Auto-merge is a GitHub feature that schedules a pull request to automatically merge once all of the required "checks" have happened. In our case, that means tests pass and a reviewer has approved it. Enabling auto-merge means that Talent Team will only need to approve the archival pull request and it will merge on its own after that. It's just a convenience feature.