### PR TITLE
Small tweaks: minor typo fix, and updates to make archive PRs easier to identify

### DIFF
--- a/.github/workflows/archive_closed_jobs.yml
+++ b/.github/workflows/archive_closed_jobs.yml
@@ -55,7 +55,8 @@ jobs:
           echo -e "This pull request was created automatically. It is archiving job postings that are now closed. The pull request will merge automatically once it has been approved.\n\nApproving this pull request will move the following jobs into the archive:\n${{ steps.archive.outputs.archived_jobs }}\n\nNote: These jobs are already shown as CLOSED on the TTSJobs site. This pull request is not necessary to mark these jobs as closed. It is just for moving them to the archive to help keep a tidy repo. 🙂" > PR_BODY
           gh pr create \
             --base main \
-            --title "Archive closed jobs" \
+            --title "🛄 Archive closed jobs" \
+            --label "archive"
             --body-file PR_BODY
           gh pr merge --auto --squash
 

--- a/positions/usdc-deputy-director.md
+++ b/positions/usdc-deputy-director.md
@@ -26,7 +26,7 @@ platforms, and services.
 
 ## Role Summary:
 
-The U.S. Digital Corps [USDC](https://digitalcorps.gsa.gov/) is a two-year
+The U.S. Digital Corps ([USDC](https://digitalcorps.gsa.gov/)) is a two-year
 fellowship for early-career technologists to launch impactful careers in public
 service and create a more effective, equitable government. USDC pairs
 early-career, mission-driven software engineers, data scientists, product


### PR DESCRIPTION
- fixes a typo originally fixed in #957
- updates archive PRs to begin with 🛄 and be labeled with `archive` to make them easier to identify in the list