### PR TITLE
When the TTSJobs site is updated, also update the Handbook if appropriate

### DIFF
--- a/.github/workflows/update_handbook.yaml
+++ b/.github/workflows/update_handbook.yaml
@@ -31,8 +31,7 @@ jobs:
           bundler-cache: true
       
       # We need to build the site first because that will produce the JSON file
-      # we need as well as the rendered jobs pages that we might need to add to
-      # the archive.
+      # we need to copy over to the Handbook.
       - name: build the site
         run: bundle exec jekyll build
 

--- a/.github/workflows/update_handbook.yaml
+++ b/.github/workflows/update_handbook.yaml
@@ -1,0 +1,81 @@
+name: update TTS Handbook
+
+on:
+  push:
+    branches:
+      main
+
+jobs:
+  update:
+    name: update TT Handbook
+    runs-on: ubuntu-latest
+    env:
+      LANG: C.UTF-8
+    
+    steps:
+      # Rather than use a personal access token to interact with the project, we
+      # can use this GitHub App. There's an API for exchanging app credentials
+      # for a short-term token, and we use that API here.
+      - name: get token
+        uses: tibdex/github-app-token@v1
+        id: app_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          installation_id: ${{ secrets.APP_INSTALLATION_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      
+      # We need to build the site first because that will produce the JSON file
+      # we need as well as the rendered jobs pages that we might need to add to
+      # the archive.
+      - name: build the site
+        run: bundle exec jekyll build
+
+      # Now get the Handbook
+      - uses: actions/checkout@v3
+        with:
+          repository: 18f/handbook
+          path: .HANDBOOK
+          # Check it out using the app token rather than the action token. This
+          # way we can push to a branch. The action token doesn't have write
+          # permission on other repos, but the app token does.
+          token: ${{ steps.app_token.outputs.token }}
+      
+      - name: copy jobs data file
+        run: rsync _site/jobs.json .HANDBOOK/_data/jobs.json
+      
+      - name: check if changes have been made
+        id: diff
+        run: |
+          cd .HANDBOOK
+          if [[ `git status --porcelain` ]]
+          then
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.diff.outputs.has_diff == 'true'
+        name: update the handbook
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          export BRANCH="job-sync/$(date +"%s")"
+          cd .HANDBOOK
+          git config --global user.email "bot@tts.gsa.gov"
+          git config --global user.name "TTSJobs → Handbook Sync"
+          git checkout -b job-sync/auto
+          git add _data/jobs.json
+          git commit -m "syncing jobs from TTSJobs"
+          git push -f origin job-sync/auto
+          echo -e "This pull request was created automatically to synchronize the Handbook TTSJobs page with join.tts.gsa.gov. This PR will merge automatically once it has been reviewed and approved." > PR_BODY
+          gh pr create \
+            --title "🔁 Synchronize jobs from TTSJobs" \
+            --label "TTS Jobs" \
+            --body-file PR_BODY || true
+          gh pr merge --auto --squash
+
+

--- a/.github/workflows/update_handbook.yaml
+++ b/.github/workflows/update_handbook.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update:
-    name: update TT Handbook
+    name: update TTS Handbook
     runs-on: ubuntu-latest
     env:
       LANG: C.UTF-8

--- a/pages/jobs.html
+++ b/pages/jobs.html
@@ -21,7 +21,7 @@ make sure that any changes here are reflected there as well!
     {%- assign status = item | job_posting_status %}
     {%- if status == "open" %}
       {%- capture text -%}
-        This role is open for applications until {{ item["closes"] | human_friendly }}, at 11:59 pm ET{% if max > 0 %} OR {{ max }} applications have been received{% endif %}.
+        This role is open for applications until {{ item["closes"] | human_friendly }}, at 11:59 pm ET{% if max > 0 %} OR{{ max }} applications have been received{% endif %}.
       {%- endcapture -%}
     {%- endif -%}
 


### PR DESCRIPTION
Changes proposed in this pull request:
- When the TTSJobs site is updated...
  - copies the Handbook repo
  - check is the jobs data in TTSJobs is different from the Handbook
  - if so, makes the changes in the Handbook
  - creates a pull request in the Handbook repo with the changes
