### PR TITLE
Include closed jobs in the jobs API

### DIFF
--- a/pages/jobs.html
+++ b/pages/jobs.html
@@ -13,10 +13,7 @@ make sure that any changes here are reflected there as well!
 {%- for page in site.pages -%}
 {%- assign bits = page["path"] | split: "/" -%}
 {%- if bits[0] == "positions" -%}
-  {%- assign status = page | job_posting_status -%}
-  {%- if status != "closed" -%}
-    {%- assign list = list | push: page -%}
-  {%- endif -%}
+  {%- assign list = list | push: page -%}
 {%- endif -%} {%- endfor -%}
 [
   {% for item in list %}


### PR DESCRIPTION
This PR updates the jobs static API to include closed jobs. The static API is used by the auto-archiver, so it needs to see the closed jobs in order to know what to archive. Oopsie on my part!

See for example:
- the [production API](https://join.tts.gsa.gov/jobs.json) does not include the TTS PeopleOps role, which is technically closed (though I think it's marked as closed as a hack to get it off the front page?)
- the [preview API](https://federalist-217d62ed-a40b-4e63-ab27-952ee578ef00.sites.pages.cloud.gov/preview/18f/join.tts.gsa.gov/fix-jobs-api/jobs.json), which does include the TTS PeopleOps role