### PR TITLE
Fix a bug with styling on the front page when a job has non-future info sessions

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -46,8 +46,9 @@ permalink: /
         {% for job in open %}
           {% unless job.path contains 'template' %}
           {% unless job.path contains 'performance-profiles' %}
-          <li class="{% if job["info sessions"].size > 0 %}with-info-sessions{% endif %}">
-            <a href="{{ site.baseurl }}{{ job.url }}">{{ job.title }}</a>
+          {% assign info_sessions = job | future_info_sessions_for_job %}
+          <li class="{% if info_sessions.size > 0 %}with-info-sessions{% endif %}">
+            {{ infosessions.size }}<a href="{{ site.baseurl }}{{ job.url }}">{{ job.title }}</a>
             (Open now through {{ job.closes | human_friendly }}{% if job["max applications"] > 0 %}, or when {{ job["max applications"] }} applications have been received{% endif %})
             {%- include info_sessions.html job=job %}
           </li>
@@ -68,7 +69,8 @@ permalink: /
         {% for job in upcoming %}
           {% unless job.path contains 'template' %}
           {% unless job.path contains 'performance-profiles' %}
-          <li class="{% if job["info sessions"].size > 0 %}with-info-sessions{% endif %}">
+          {% assign info_sessions = job | future_info_sessions_for_job %}
+          <li class="{% if info_sessions.size > 0 %}with-info-sessions{% endif %}">
             <a href="{{ site.baseurl }}{{ job.url }}">{{ job.title }}</a>
             {%- include info_sessions.html job=job %}
           </li>


### PR DESCRIPTION
On the page currently, there is a small gap between the first two upcoming positions:

![screenshot showing three bullet points: 18F engineering director GS15, 18F product director gs15, and Login deputy director gs15. There is more space between the first pair of bullets than the second pair, as indicated by a red rounded rectangle](https://user-images.githubusercontent.com/1775733/225038390-3e564503-14fd-4706-a04b-92fb4c772584.png)

This space is caused by the addition of the `with-info-session` CSS class. This class is applied conditionally, but the condition is "if the job has any info sessions." This is the wrong condition. It should instead be "if the job has any *future* info sessions." This PR updates the condition, and the extraneous space is removed:

![image](https://user-images.githubusercontent.com/1775733/225039242-d171e947-7880-4c4c-b9b6-f67831231659.png)
