### PR TITLE
bump up upcoming position to an h3

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -71,7 +71,7 @@ permalink: /
           {% unless job.path contains 'performance-profiles' %}
           {% assign info_sessions = job | future_info_sessions_for_job %}
           <li class="{% if info_sessions.size > 0 %}with-info-sessions{% endif %}">
-            <a href="{{ site.baseurl }}{{ job.url }}">{{ job.title }}</a>
+            <h3><a href="{{ site.baseurl }}{{ job.url }}">{{ job.title }}</a></h3>
             {%- include info_sessions.html job=job %}
           </li>
           {% endunless %}


### PR DESCRIPTION
Fixes issue(s) # .

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/lg/da-team-ticket-99/)

Changes proposed in this pull request:
- update the relative hierarchy of upcoming positions on the homepage 
-
-

/cc @relevant-people
