### PR TITLE
Add templates and logic to allow PIF/USDC/etc. postings outside of JoinTTS's site

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -47,8 +47,13 @@ permalink: /
           {% unless job.path contains 'template' %}
           {% unless job.path contains 'performance-profiles' %}
           {% assign info_sessions = job | future_info_sessions_for_job %}
+          {% if job["information link"] %}
+            {% assign link_url = job["information link"] %}
+          {% else %}
+            {% assign link_url = site.baseurl | append: job.url %}
+          {% endif %}
           <li class="{% if info_sessions.size > 0 %}with-info-sessions{% endif %}">
-            {{ infosessions.size }}<a href="{{ site.baseurl }}{{ job.url }}">{{ job.title }}</a>
+            {{ infosessions.size }}<a href="{{ link_url }}">{{ job.title }}</a>
             (Open now through {{ job.closes | human_friendly }}{% if job["max applications"] > 0 %}, or when {{ job["max applications"] }} applications have been received{% endif %})
             {%- include info_sessions.html job=job %}
           </li>

--- a/pages/index.md
+++ b/pages/index.md
@@ -53,7 +53,7 @@ permalink: /
             {% assign link_url = site.baseurl | append: job.url %}
           {% endif %}
           <li class="{% if info_sessions.size > 0 %}with-info-sessions{% endif %}">
-            {{ infosessions.size }}<a href="{{ link_url }}">{{ job.title }}</a>
+            <a href="{{ link_url }}">{{ job.title }}</a>
             (Open now through {{ job.closes | human_friendly }}{% if job["max applications"] > 0 %}, or when {{ job["max applications"] }} applications have been received{% endif %})
             {%- include info_sessions.html job=job %}
           </li>

--- a/positions/_TEMPLATE.md
+++ b/positions/_TEMPLATE.md
@@ -1,7 +1,7 @@
 ---
 ################################################################################
 #                                                                              #
-# INSTRUCTIONS                                                                 #
+# INSTRUCTIONS: TTS JOB TEMPLATE                                               #
 #                                                                              #
 # -----------------------------------------------------------------------------#
 # If you are editing this file on GitHub, first make sure you are creating a   #
@@ -13,7 +13,7 @@
 # box. You will see the text join.tts.gsa.gov / [ Name your file ...] in main. #
 # Type your filename into that box.                                            #
 #                                                                              #
-# NOTE ABOUTE FILENAMES: Your filename should be descriptive about the job     #
+# NOTE ABOUT FILENAMES: Your filename should be descriptive about the job      #
 # posting that you're creating, and it MUST end with ".md". Don't stress out   #
 # about filenames too much, though. They are used for the URL, which can help  #
 # people make sure they're on the right page, but most users will probably not #

--- a/positions/_TEMPLATE_PIF_USDC.md
+++ b/positions/_TEMPLATE_PIF_USDC.md
@@ -1,0 +1,124 @@
+---
+################################################################################
+#                                                                              #
+# INSTRUCTIONS: PIF/USDC/ETC JOB TEMPLATE                                      #
+#                                                                              #
+# -----------------------------------------------------------------------------#
+# If you are editing this file on GitHub, first make sure you are creating a   #
+# new file, and are not editing the template file! To create a new file, go to #
+# https://github.com/18F/join.tts.gsa.gov/new/main/positions in your browser.  #
+#                                                                              #
+# On the new file page, you can paste in the contents of the template file.    #
+# Also be sure to type in a filename in the small textbox above the file body  #
+# box. You will see the text join.tts.gsa.gov / [ Name your file ...] in main. #
+# Type your filename into that box.                                            #
+#                                                                              #
+# NOTE ABOUT FILENAMES: Your filename should be descriptive about the job      #
+# posting that you're creating, and it MUST end with ".md". Don't stress out   #
+# about filenames too much, though. They are used for the URL, which can help  #
+# people make sure they're on the right page, but most users will probably not #
+# notice the URL. Instead, try to make it meaningful to you and others on the  #
+# Talent Team so you can find it easily in the future if you need to edit it.  #
+#                                                                              #
+# For example, if you are posting a job for a content designer, you might      #
+# choose names like:                                                           #
+#                                                                              #
+#    tts-content-designer-2023.md                                              #
+#    login-content-designer-2023.md                                            #
+#    content-designer-2023.md                                                  #
+#    content-designer-june-2023.md                                             #
+#                                                                              #
+# For the rest of the file, follow the directions as you go, but here are a    #
+# couple more tips to help you as you work:                                    #
+#                                                                              #
+# You are currently inside the portion of the document called "frontmatter."   #
+# The frontmatter is the part that starts with just "---" on the first line    #
+# and ends with another line that only contains "---" (further down). This     #
+# part of the document is not DIRECTLY shown to the user. Instead, this is     #
+# where you can set data that will be shown to the user in other parts of the  #
+# page, or data that is used to configure how the page is displayed. For       #
+# example, the opens and closes dates are set in the frontmatter, but they     #
+# will never be shown to the user the way you type them in. Instead, they are  #
+# used to determine whether the posting is upcoming, open, or closed, and they #
+# will be turned into more human-friendly text when they are displayed.        #
+#                                                                              #
+# Within this frontmatter block, lines that begin with a hash (#) symbol are   #
+# comments. They do not contribute to the web page at all, but they are a nice #
+# way of explaining what the data in the frontmatter is. It is okay to delete  #
+# these comments when you are done, and it is also okay to leave them if they  #
+# might be helpful when editing the page later.                                #
+#                                                                              #
+# The parts you need to fill out are marked with five red triangles above them #
+# like this:                                                                   #
+#🔻🔻🔻🔻🔻                                                                   #
+#                                                                              #
+# It is safe to remove the Markdown comments as well.                          #
+#                                                                              #
+################################################################################
+
+# This is the position title and the org that is doing the hiring. Please format
+# your title as "Org: Position Title" (in quotes!). The organization should be
+# a full name rather than an acronym. For example:
+#   - U.S. Digital Corps, not USDC
+#   - Presidential Innovation Fellows, not PIF
+# The exception to this is a TTS role, for which you can just say TTS. 
+#
+# NOTE: Be sure to leave the "title: " part at the beginning! These line
+# headings are how the site builder knows what the data is. For the rest of the
+# frontmatter, please be careful not to delete the headings!
+#🔻🔻🔻🔻🔻
+title: "Hiring Org: Position title"
+
+# Put the opening and closing dates of your posting here, if you have them. The
+# values you set here will be turned into user-friendly text in other parts of
+# this post. Setting it here means you won't have to copy it over and over.
+#
+# These dates MUST be formatted as YYYY-MM-DD, where month and day are 2-digits.
+# If the month number or day of the month are less than 10, add a 0 to the
+# front (eg, May would be 05 instead of just 5). This is the only format the
+# site builder automatically understands. Anything else will not be understood
+# as a date.
+#🔻🔻🔻🔻🔻
+opens: 2023-02-01
+closes: 2023-02-22
+# These dates are also used to determine whether a position is upcoming, open,
+# or closed. Here's how we decide:
+#
+# The job is upcoming if:
+#   opens is empty OR
+#   opens is in the future
+#
+# The job is open if:
+#   opens is in the past OR
+#   closes is in the future
+#
+# The job is closed if:
+#   closes is in the past
+#
+# If either opens or closes is empty, missing, or not a date, the position is
+# considered to be upcoming.
+
+# If there are any info sessions associated with this position, list them here.
+# Each info session needs three pieces of information: the link, the date, and
+# the time. See the placeholder below for an example of how to add an info
+# session. If the position does not have any info sessions, you can just delete
+# the lines that begin with spaces.
+#
+# IMPORTANT: The date MUST be formatted as YYYY-MM-DD, where the month and day
+# are TWO digits. If the month or day is less than 10, add a zero to the front.
+# The date is used to sort the info sessions on the page so they are shown
+# nearest to furthest. Only info sessions schedule for the future will be shown.
+#🔻🔻🔻🔻🔻
+info sessions:
+  - link: https://www.eventbrite.com/...
+    date: 2023-02-13
+    time: 1:30-2:30pm ET (10:30am -11:30am PT)
+
+# Put the link to the PIF, USDC, or other site where the job description is 
+# located. This will point the user to that site rather than a posting on the
+# JoinTTS site.
+#🔻🔻🔻🔻🔻
+information link: https://presidentialinnovationfellows.gov/apply/
+
+# This is the end of the frontmatter. After this line is Markdown.
+---


### PR DESCRIPTION

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/add-pif-template/)

Changes proposed in this pull request:
- Add a TEMPLATE_PIF_USDC.md which describes a PIF/USDC/etc. position
- Template also adds a "application link" which is the URL to the site with the description
- Logic is added to the home page to mix these jobs with the others

This does not add any additional jobs.

/cc @LeighFinkel 
