### PR TITLE
Add PIF/USDC template change to upcoming jobs too (already in open)

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -75,8 +75,13 @@ permalink: /
           {% unless job.path contains 'template' %}
           {% unless job.path contains 'performance-profiles' %}
           {% assign info_sessions = job | future_info_sessions_for_job %}
+          {% if job["information link"] %}
+            {% assign link_url = job["information link"] %}
+          {% else %}
+            {% assign link_url = site.baseurl | append: job.url %}
+          {% endif %}
           <li class="{% if info_sessions.size > 0 %}with-info-sessions{% endif %}">
-            <h3><a href="{{ site.baseurl }}{{ job.url }}">{{ job.title }}</a></h3>
+            <h3><a href="{{ link_url }}">{{ job.title }}</a></h3>
             {%- include info_sessions.html job=job %}
           </li>
           {% endunless %}


### PR DESCRIPTION
Fixes issue(s): N/A

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/add-pif-template-upcoming/)

Changes proposed in this pull request:
- The change to let PIF/USDC/etc. jobs link to an outside site only was on open positions, not upcoming. This fixes that

/cc @LeighFinkel 