### PR TITLE
Fix archiver using wrong fs variable, not offsetting right

### DIFF
--- a/.github/workflows/archive_closed_jobs.js
+++ b/.github/workflows/archive_closed_jobs.js
@@ -8,7 +8,7 @@ const _path = require("path");
 // we can say the two are basically the same thing.
 const exists = async (path) => {
   try {
-    await fs.access(path);
+    await _fs.access(path);
     return true;
   } catch (e) {
     return false;
@@ -55,8 +55,9 @@ const runArchiver = async ({ core, fs = _fs, path = _path }) => {
     const archivePath = await (async () => {
       const archiveBase = path.join("archive", path.basename(pathname));
       let archivePath = archiveBase;
-      let offset = 1;
+      let offset = 0;
       while (await exists(archivePath)) {
+        offset++;
         archivePath = `${archiveBase}_${offset}`;
       }
       return archivePath;

--- a/.github/workflows/archive_closed_jobs.yml
+++ b/.github/workflows/archive_closed_jobs.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     # 1000 UTC will always be after midnight ET.
     - cron: 0 10 * * *
-  pull_request:
 
 jobs:
   archive:

--- a/.github/workflows/archive_closed_jobs.yml
+++ b/.github/workflows/archive_closed_jobs.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # 1000 UTC will always be after midnight ET.
     - cron: 0 10 * * *
+  pull_request:
 
 jobs:
   archive:
@@ -18,7 +19,7 @@ jobs:
         with:
           ruby-version: 2.7
           bundler-cache: true
-      
+
       # We need to build the site first because that will produce the JSON file
       # we need as well as the rendered jobs pages that we might need to add to
       # the archive.
@@ -49,7 +50,7 @@ jobs:
       #    the file as the PR body.
       # 6. Create a pull request from the archiver/auto branch into main. If a
       #    PR already exists for that source/target, this command will fail, but
-      #    in that case we don't care because the PR will have been updated in 
+      #    in that case we don't care because the PR will have been updated in
       #    step 4. So to keep this workflow from failing, we throw a "|| true"
       #    on the end of the command. This ensures the command never fails.
       # 7. Set the PR to auto-merge. This is just a convenience, but it's nice.


### PR DESCRIPTION
Fixes issue(s) N/A

(no preview)

Changes proposed in this pull request:
- Fixes a bug in the archiver script that appeared to use the `fs` library but didn't, which causes it always to act like a directory never existed
- Adds the offset incrementer, which should name directories that match names with a number after it (`job`, `job_1`, `job_2`, etc.)

/cc @mgwalker @rahearn 