### PR TITLE
fix infosec appointment type

### DIFF
--- a/positions/Information Technology Specialist GS15 INFOSEC.md
+++ b/positions/Information Technology Specialist GS15 INFOSEC.md
@@ -117,7 +117,7 @@ closes: 2023-10-30
 # will be used to fill in the appointment type on the page with consistent
 # language.
 #🔻🔻🔻🔻🔻
-appointment type: term
+appointment type: perm
 
 # Put the GS grade this position is being advertised at. For SES positions, set
 # the level to 20.


### PR DESCRIPTION
The Tech to Gov INFOSEC role was displaying as a term position in the body, but perm in the title.

Fixes issue(s) # .

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/join.tts.gsa.gov/BRANCH_NAME/)

Changes proposed in this pull request:
- switch term to perm in the appointment type field.
-
-

/cc @relevant-people
