### PR TITLE
Fix the archiver

### DIFF
--- a/.github/workflows/archive_closed_jobs.js
+++ b/.github/workflows/archive_closed_jobs.js
@@ -44,7 +44,7 @@ const runArchiver = async ({ core, fs = _fs }) => {
     //
     // NOTE: Jobs from /positions are rendered to:
     //   /join/[filename slug]/index.html
-    const pathname = new URL(job.url).pathname;
+    const pathname = decodeURIComponent(new URL(job.url).pathname);
     const renderedPath = path.join("_site", pathname);
 
     // For its archival location, we just yoink out the last directory

--- a/.github/workflows/archive_closed_jobs.test.js
+++ b/.github/workflows/archive_closed_jobs.test.js
@@ -111,5 +111,33 @@ tap.test("automatic job archival", async (t1) => {
       );
       t3.ok(fs.rm.calledWith("positions/the_filename.md"));
     });
+
+    t2.test("there are spaces in the filename", async (t3) => {
+      fs.readFile.withArgs("_site/jobs.json").resolves(
+        JSON.stringify([
+          {
+            name: "the_filename.md",
+            title: "closed job #1",
+            status: "closed",
+            url: "https://tts.gsa.gov/path/file%20name",
+          },
+        ])
+      );
+
+      fs.access.withArgs("archive/file%20name").rejects();
+
+      await archiver({ core, fs });
+
+      console.log(fs.rename.args);
+
+      t3.ok(fs.rename.calledWith("_site/path/file name", "archive/file name"));
+      t3.ok(
+        fs.writeFile.calledWith(
+          "archive/name/index.html",
+          `${FRONTMATTER}\n${RENDERED_CONTENT}`
+        )
+      );
+      t3.ok(fs.rm.calledWith("positions/the_filename.md"));
+    });
   });
 });


### PR DESCRIPTION
The automatic archiver assumes that all jobs are using slug filenames, but it turns out that's sometimes not the case. This PR updates the archiver to URI-decode paths in case they're not slugified.

Jobs that need to be pushed into the archive will be archived the next time the archiver runs after this PR is merged.